### PR TITLE
Fix MPC constraint bounds and solution access

### DIFF
--- a/src/car_mpc_node.cpp
+++ b/src/car_mpc_node.cpp
@@ -193,14 +193,16 @@ private:
 
         cddp_solver_->addPathConstraint(
             "ControlConstraint",
-            std::make_unique<cddp::ControlConstraint>(upper_bound, lower_bound)
+            std::make_unique<cddp::ControlConstraint>(lower_bound, upper_bound)
         );
 
         // Add state constraints on velocity
-        Eigen::VectorXd state_upper_bound(1);
-        state_upper_bound << 2.0;
+        Eigen::VectorXd state_lower_bound(state_dim);
+        state_lower_bound << -1e6, -1e6, -M_PI, -2.0;
+        Eigen::VectorXd state_upper_bound(state_dim);
+        state_upper_bound << 1e6, 1e6, M_PI, 2.0;
         cddp_solver_->addPathConstraint("StateConstraint",
-                                       std::make_unique<cddp::StateConstraint>(state_upper_bound));
+                                       std::make_unique<cddp::StateConstraint>(state_lower_bound, state_upper_bound));
 
         // Set some solver options
         cddp::CDDPOptions options;
@@ -298,9 +300,9 @@ private:
         cddp::CDDPSolution solution = cddp_solver_->solve("MSIPDDP");
 
         // Extract solution
-        auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory")); // size: horizon + 1
-        auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory")); // size: horizon
-        auto t_sol = std::any_cast<std::vector<double>>(solution.at("time_points")); // size: horizon + 1   
+        const auto& X_sol = solution.state_trajectory; // size: horizon + 1
+        const auto& U_sol = solution.control_trajectory; // size: horizon
+        const auto& t_sol = solution.time_points; // size: horizon + 1
 
         // Extract control
         Eigen::VectorXd u = U_sol[0];

--- a/src/car_mpc_node.cpp
+++ b/src/car_mpc_node.cpp
@@ -302,7 +302,6 @@ private:
         // Extract solution
         const auto& X_sol = solution.state_trajectory; // size: horizon + 1
         const auto& U_sol = solution.control_trajectory; // size: horizon
-        const auto& t_sol = solution.time_points; // size: horizon + 1
 
         // Extract control
         Eigen::VectorXd u = U_sol[0];

--- a/src/mpc_node.cpp
+++ b/src/mpc_node.cpp
@@ -179,7 +179,7 @@ private:
 
         cddp_solver_->addPathConstraint(
             "ControlConstraint",
-            std::make_unique<cddp::ControlConstraint>(upper_bound, lower_bound)
+            std::make_unique<cddp::ControlConstraint>(lower_bound, upper_bound)
         );
 
         // Set some solver options
@@ -277,9 +277,9 @@ private:
         cddp::CDDPSolution solution = cddp_solver_->solve("MSIPDDP");
 
         // Extract solution
-        auto X_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("state_trajectory")); // size: horizon + 1
-        auto U_sol = std::any_cast<std::vector<Eigen::VectorXd>>(solution.at("control_trajectory")); // size: horizon
-        auto t_sol = std::any_cast<std::vector<double>>(solution.at("time_points")); // size: horizon + 1   
+        const auto& X_sol = solution.state_trajectory; // size: horizon + 1
+        const auto& U_sol = solution.control_trajectory; // size: horizon
+        const auto& t_sol = solution.time_points; // size: horizon + 1
 
         // Extract control
         Eigen::VectorXd u = U_sol[0];

--- a/src/mpc_node.cpp
+++ b/src/mpc_node.cpp
@@ -279,7 +279,6 @@ private:
         // Extract solution
         const auto& X_sol = solution.state_trajectory; // size: horizon + 1
         const auto& U_sol = solution.control_trajectory; // size: horizon
-        const auto& t_sol = solution.time_points; // size: horizon + 1
 
         // Extract control
         Eigen::VectorXd u = U_sol[0];


### PR DESCRIPTION
## Summary

Fix the MPC nodes after the parent solver update by correcting constraint bound ordering and switching to the typed `CDDPSolution` trajectory fields.

## Changes

- Swap `ControlConstraint` construction to pass `lower_bound, upper_bound` in both MPC nodes.
- Add explicit lower and upper `StateConstraint` bounds for the car MPC node.
- Replace map-style `solution.at(...)` and `std::any_cast` access with direct `CDDPSolution` trajectory fields.

## Test Plan

- `git diff --cached --check`
- Not run: `colcon build --packages-select cddp_mpc --cmake-args -DCMAKE_BUILD_TYPE=Release` (`colcon: command not found` in this environment)

## Related Issues

None noted.

## How to Test

- Build `cddp_mpc` in a ROS 2 Humble environment.
- Run the standard MPC node and the car MPC node against the updated solver.
- Confirm solver startup succeeds and the configured control and state bounds are enforced.

## Screenshots/Videos

None.

## Additional Notes

- The branch diff contains a single commit: `965a225`.
