### PR TITLE
Add multi-quadrotor launch and topic prefix support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,11 @@ set(CMAKE_BUILD_TYPE "Release") # Set the build type to Release by default
 find_package(ament_cmake REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
+find_package(interactive_markers REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(px4_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
@@ -45,6 +47,7 @@ add_executable(
   px4_mpc_node
   src/px4_mpc_node.cpp
   src/indi_rotational_compensator.cpp
+  src/reference_manager.cpp
   src/reference_provider.cpp
 )
 target_include_directories(px4_mpc_node PUBLIC
@@ -53,9 +56,13 @@ target_include_directories(px4_mpc_node PUBLIC
 )
 ament_target_dependencies(px4_mpc_node
   diagnostic_msgs
+  geometry_msgs
+  nav_msgs
   rclcpp
   px4_msgs
+  sensor_msgs
   std_srvs
+  visualization_msgs
   Eigen3
 )
 target_link_libraries(px4_mpc_node
@@ -71,6 +78,7 @@ ament_target_dependencies(px4_visualizer
   diagnostic_msgs
   Eigen3
   geometry_msgs
+  interactive_markers
   nav_msgs
   px4_msgs
   rclcpp
@@ -196,6 +204,26 @@ if(BUILD_TESTING)
       Threads::Threads
     )
     add_test(NAME test_reference_provider COMMAND test_reference_provider)
+  endif()
+
+  add_executable(
+    test_reference_manager
+    test/test_reference_manager.cpp
+    src/reference_manager.cpp
+  )
+  if(TARGET test_reference_manager)
+    target_include_directories(test_reference_manager PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+      ${GTEST_INCLUDE_DIR}
+    )
+    ament_target_dependencies(test_reference_manager Eigen3)
+    target_link_libraries(test_reference_manager
+      ${GTEST_LIBRARY}
+      ${GTEST_MAIN_LIBRARY}
+      Threads::Threads
+    )
+    add_test(NAME test_reference_manager COMMAND test_reference_manager)
   endif()
 
   add_executable(

--- a/README.md
+++ b/README.md
@@ -138,6 +138,49 @@ ros2 launch cddp_mpc mpc_offboard.launch.py
 ros2 launch cddp_mpc mpc_offboard.launch.py params_file:=/path/to/params.yaml
 ```
 
+### Running Multiple Quadrotors in SITL
+
+The repo now has fleet-oriented launch wrappers built on top of the single-vehicle
+controller path.
+
+Start a multi-vehicle PX4 SITL stack:
+
+```bash
+# Shell 1 inside the persistent dev container
+sb
+ros2 launch cddp_mpc multi_quadrotor_simulation.launch.py vehicle_count:=2
+```
+
+Start one controller per PX4 instance:
+
+```bash
+# Shell 2 inside the same container
+sb
+ros2 launch cddp_mpc multi_quadrotor_offboard.launch.py vehicle_count:=2
+```
+
+Default fleet conventions:
+
+- PX4 instance `0` uses ROS topics under `/px4_0/fmu` and controller topics under `/px4_0/cddp_mpc`
+- PX4 instance `1` uses `/px4_1/fmu` and `/px4_1/cddp_mpc`
+- each controller publishes `VehicleCommand` with `target_system = instance + 1`
+- per-vehicle overlays live in [`config/fleet`](config/fleet)
+
+Useful overrides:
+
+```bash
+# Launch RViz for only px4_0 while keeping both controllers running
+ros2 launch cddp_mpc multi_quadrotor_offboard.launch.py \
+  vehicle_count:=2 launch_rviz:=true rviz_instance:=0
+
+# Start controllers from a different base config
+ros2 launch cddp_mpc multi_quadrotor_offboard.launch.py \
+  vehicle_count:=3 params_file:=/path/to/base.yaml
+```
+
+The packaged RViz config is rewritten at launch time so the visualizer and goal
+topics point at the selected vehicle instance.
+
 When `launch_visualizer:=true` or `launch_rviz:=true`, the package starts
 `px4_visualizer`, which publishes:
 
@@ -147,9 +190,39 @@ When `launch_visualizer:=true` or `launch_rviz:=true`, the package starts
 - `/px4_visualizer/vehicle_velocity`
 - `/px4_visualizer/setpoint_marker`
 
+It also hosts an interactive marker server at
+`/cddp_mpc/interactive_goal`, so the packaged RViz config can drag the
+goal reference directly in the `map` frame.
+
 These are standard ROS topics for visualization. You can start `rviz2` with the
 packaged `rviz/px4_visualizer.rviz` config from either the simulation launch or
 the MPC launch using `launch_rviz:=true`.
+
+### Teleop and goal-reference inputs
+
+The controller now accepts higher-level reference inputs without bypassing the
+MPC or final safety gate:
+
+- `/teleop/cmd_vel` (`geometry_msgs/msg/TwistStamped`) for velocity teleop
+- `/joy` (`sensor_msgs/msg/Joy`) for the teleop deadman button
+- `/cddp_mpc/goal_pose` (`geometry_msgs/msg/PoseStamped`) for external/RViz goal poses
+
+These inputs feed the reference manager, which arbitrates them against the
+mission state and keeps the command path `reference -> MPC -> safety gate -> PX4`.
+Goal poses are accepted in the configured world frame (`map` by default).
+
+With the packaged RViz config, the **SetGoal** tool now targets
+`/cddp_mpc/goal_pose`, so you can drive horizontal goal updates from RViz
+without bypassing the MPC. The **Interact** tool can also drag the
+`Goal Marker`, which publishes the same `PoseStamped` interface through
+`/cddp_mpc/goal_pose`.
+
+For visualization, `px4_mpc_node` also publishes:
+
+- `/cddp_mpc/active_goal`
+- `/cddp_mpc/predicted_path`
+- `/cddp_mpc/geofence`
+- `/cddp_mpc/safety_text`
 
 ### Hardware Validation Launch
 

--- a/config/fleet/px4_0.yaml
+++ b/config/fleet/px4_0.yaml
@@ -1,0 +1,13 @@
+cddp_mpc:
+  ros__parameters:
+    fmu_prefix: /px4_0/fmu
+    controller_prefix: /px4_0/cddp_mpc
+    target_system: 1
+    target_component: 1
+    source_system: 1
+    source_component: 1
+    teleop_topic: /px4_0/teleop/cmd_vel
+    joy_topic: /px4_0/joy
+    goal_pose_topic: /px4_0/cddp_mpc/goal_pose
+    target_x_m: 0.0
+    target_y_m: 0.0

--- a/config/fleet/px4_1.yaml
+++ b/config/fleet/px4_1.yaml
@@ -1,0 +1,13 @@
+cddp_mpc:
+  ros__parameters:
+    fmu_prefix: /px4_1/fmu
+    controller_prefix: /px4_1/cddp_mpc
+    target_system: 2
+    target_component: 1
+    source_system: 2
+    source_component: 1
+    teleop_topic: /px4_1/teleop/cmd_vel
+    joy_topic: /px4_1/joy
+    goal_pose_topic: /px4_1/cddp_mpc/goal_pose
+    target_x_m: 0.0
+    target_y_m: 2.0

--- a/examples/calibrate_hover_mass.py
+++ b/examples/calibrate_hover_mass.py
@@ -26,10 +26,12 @@ class CalibrationConfig:
     max_thrust_n: float = 20.0
     include_takeoff_mode: bool = False
     require_armed_offboard: bool = True
+    fmu_prefix: str = "/fmu"
+    controller_prefix: str = "/cddp_mpc"
 
 
 class HoverMassCalibrator(Node):
-    """Collect steady hover samples from /cddp_mpc/status."""
+    """Collect steady hover samples from the configured cddp_mpc status topic."""
 
     def __init__(self, config: CalibrationConfig):
         super().__init__("hover_mass_calibrator")
@@ -56,15 +58,18 @@ class HoverMassCalibrator(Node):
         self.current_thrust = float("nan")
         self.hover_thrust_samples: list[float] = []
 
+        fmu_prefix = self.config.fmu_prefix.rstrip("/") or "/fmu"
+        controller_prefix = self.config.controller_prefix.rstrip("/") or "/cddp_mpc"
+
         self.create_subscription(
             VehicleStatus,
-            "/fmu/out/vehicle_status",
+            f"{fmu_prefix}/out/vehicle_status",
             self._status_callback,
             qos_profile,
         )
         self.create_subscription(
             DiagnosticArray,
-            "/cddp_mpc/status",
+            f"{controller_prefix}/status",
             self._diagnostic_callback,
             qos_profile,
         )
@@ -157,8 +162,10 @@ class HoverMassCalibrator(Node):
 
 def parse_args() -> CalibrationConfig:
     parser = argparse.ArgumentParser(
-        description="Estimate hover thrust calibration from /cddp_mpc/status."
+        description="Estimate hover thrust calibration from the configured cddp_mpc status topic."
     )
+    parser.add_argument("--fmu-prefix", type=str, default="/fmu")
+    parser.add_argument("--controller-prefix", type=str, default="/cddp_mpc")
     parser.add_argument("--duration-sec", type=float, default=25.0)
     parser.add_argument("--min-samples", type=int, default=30)
     parser.add_argument("--vz-threshold-mps", type=float, default=0.2)
@@ -175,6 +182,8 @@ def parse_args() -> CalibrationConfig:
         max_thrust_n=args.max_thrust_n,
         include_takeoff_mode=args.include_takeoff_mode,
         require_armed_offboard=not args.allow_unarmed,
+        fmu_prefix=args.fmu_prefix,
+        controller_prefix=args.controller_prefix,
     )
 
 

--- a/examples/validate_takeoff_hover.py
+++ b/examples/validate_takeoff_hover.py
@@ -23,6 +23,8 @@ from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 @dataclass
 class ValidationConfig:
     validation_mode: str = "offboard"
+    fmu_prefix: str = "/fmu"
+    controller_prefix: str = "/cddp_mpc"
     target_z: float = -3.0
     settle_tolerance: float = 0.3
     hold_duration_sec: float = 0.0
@@ -82,29 +84,44 @@ class HoverMissionValidator(Node):
         self.solver_cmd_thrust = None
         self.published_cmd_thrust = None
 
+        fmu_prefix = self.config.fmu_prefix.rstrip("/") or "/fmu"
+        controller_prefix = self.config.controller_prefix.rstrip("/") or "/cddp_mpc"
+
         self.create_subscription(
-            VehicleOdometry, "/fmu/out/vehicle_odometry", self._odometry_callback, qos_profile
+            VehicleOdometry,
+            f"{fmu_prefix}/out/vehicle_odometry",
+            self._odometry_callback,
+            qos_profile,
         )
         self.create_subscription(
-            VehicleStatus, "/fmu/out/vehicle_status", self._status_callback, qos_profile
+            VehicleStatus,
+            f"{fmu_prefix}/out/vehicle_status",
+            self._status_callback,
+            qos_profile,
         )
         self.create_subscription(
-            OffboardControlMode, "/fmu/in/offboard_control_mode", self._offboard_mode_callback, qos_profile
+            OffboardControlMode,
+            f"{fmu_prefix}/in/offboard_control_mode",
+            self._offboard_mode_callback,
+            qos_profile,
         )
         self.create_subscription(
             VehicleThrustSetpoint,
-            "/fmu/in/vehicle_thrust_setpoint",
+            f"{fmu_prefix}/in/vehicle_thrust_setpoint",
             self._thrust_setpoint_callback,
             qos_profile,
         )
         self.create_subscription(
             VehicleTorqueSetpoint,
-            "/fmu/in/vehicle_torque_setpoint",
+            f"{fmu_prefix}/in/vehicle_torque_setpoint",
             self._torque_setpoint_callback,
             qos_profile,
         )
         self.create_subscription(
-            DiagnosticArray, "/cddp_mpc/status", self._diagnostic_callback, qos_profile
+            DiagnosticArray,
+            f"{controller_prefix}/status",
+            self._diagnostic_callback,
+            qos_profile,
         )
 
         self.create_timer(1.0, self._tick)
@@ -320,6 +337,8 @@ def parse_args() -> ValidationConfig:
     parser = argparse.ArgumentParser(
         description="Validate PX4 takeoff/hover/landing behavior for cddp_mpc."
     )
+    parser.add_argument("--fmu-prefix", type=str, default="/fmu")
+    parser.add_argument("--controller-prefix", type=str, default="/cddp_mpc")
     parser.add_argument("--validation-mode", choices=("offboard", "onboard"), default="offboard")
     parser.add_argument("--target-z", type=float, default=-3.0)
     parser.add_argument("--settle-tolerance", type=float, default=0.3)
@@ -343,6 +362,8 @@ def parse_args() -> ValidationConfig:
     args = parser.parse_args()
     return ValidationConfig(
         validation_mode=args.validation_mode,
+        fmu_prefix=args.fmu_prefix,
+        controller_prefix=args.controller_prefix,
         target_z=args.target_z,
         settle_tolerance=args.settle_tolerance,
         hold_duration_sec=args.hold_duration_sec,

--- a/include/cddp_mpc/reference_manager.hpp
+++ b/include/cddp_mpc/reference_manager.hpp
@@ -1,0 +1,107 @@
+#ifndef CDDP_MPC_REFERENCE_MANAGER_HPP
+#define CDDP_MPC_REFERENCE_MANAGER_HPP
+
+#include <optional>
+#include <string>
+
+#include <Eigen/Dense>
+
+namespace cddp_mpc {
+
+enum class ReferenceSource {
+  Mission,
+  GoalPose,
+  Teleop,
+};
+
+enum class TeleopFrame {
+  World,
+  Body,
+};
+
+struct ReferenceManagerConfig {
+  double smoothing_tau_s{0.6};
+  double max_xy_speed_mps{1.0};
+  double max_z_speed_mps{1.0};
+  double max_xy_accel_mps2{1.5};
+  double max_z_accel_mps2{1.5};
+  double max_yaw_rate_rad_s{0.6};
+  double teleop_timeout_s{0.2};
+  double teleop_max_xy_speed_mps{1.0};
+  double teleop_max_z_speed_mps{0.6};
+  double teleop_max_yaw_rate_rad_s{0.8};
+  bool teleop_require_deadman{true};
+  double goal_timeout_s{1.0};
+  double geofence_half_extent_x_m{5.0};
+  double geofence_half_extent_y_m{5.0};
+  double geofence_min_z_m{0.0};
+  double geofence_max_z_m{5.0};
+};
+
+struct MissionReference {
+  std::string mode{"INIT"};
+  Eigen::Vector3d target_position_enu{Eigen::Vector3d::Zero()};
+  double target_yaw_rad{0.0};
+};
+
+struct ReferenceStatus {
+  ReferenceSource source{ReferenceSource::Mission};
+  std::string source_label{"mission"};
+  Eigen::Vector3d target_position_enu{Eigen::Vector3d::Zero()};
+  double target_yaw_rad{0.0};
+  bool teleop_active{false};
+  bool teleop_deadman_pressed{false};
+  bool goal_fresh{false};
+  bool geofence_clamped{false};
+};
+
+class ReferenceManager {
+public:
+  explicit ReferenceManager(ReferenceManagerConfig config = {});
+
+  void setConfig(const ReferenceManagerConfig &config);
+  void updateTeleopCommand(double time_s, const Eigen::Vector3d &linear_velocity,
+                           double yaw_rate_rad_s, TeleopFrame frame);
+  void updateDeadmanState(double time_s, bool pressed);
+  void updateGoalPose(double time_s, const Eigen::Vector3d &position_enu,
+                      double yaw_rad);
+
+  ReferenceStatus update(double time_s, const Eigen::Vector3d &current_position_enu,
+                         double current_yaw_rad,
+                         const MissionReference &mission_reference);
+
+private:
+  struct TeleopCommand {
+    double time_s{0.0};
+    Eigen::Vector3d linear_velocity{Eigen::Vector3d::Zero()};
+    double yaw_rate_rad_s{0.0};
+    TeleopFrame frame{TeleopFrame::Body};
+  };
+
+  struct GoalPose {
+    double time_s{0.0};
+    Eigen::Vector3d position_enu{Eigen::Vector3d::Zero()};
+    double yaw_rad{0.0};
+  };
+
+  void initializeTarget(const Eigen::Vector3d &position_enu, double yaw_rad);
+  Eigen::Vector3d clampToGeofence(const Eigen::Vector3d &position_enu,
+                                  bool *clamped) const;
+  Eigen::Vector3d teleopVelocityWorld(double current_yaw_rad) const;
+  void advanceTarget(const Eigen::Vector3d &desired_position_enu, double desired_yaw_rad,
+                     double dt_s);
+
+  ReferenceManagerConfig config_;
+  std::optional<TeleopCommand> latest_teleop_command_;
+  std::optional<GoalPose> latest_goal_pose_;
+  bool deadman_pressed_{false};
+  bool initialized_{false};
+  std::optional<double> last_update_time_s_;
+  Eigen::Vector3d active_target_position_enu_{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d active_target_velocity_enu_{Eigen::Vector3d::Zero()};
+  double active_target_yaw_rad_{0.0};
+};
+
+} // namespace cddp_mpc
+
+#endif

--- a/launch/hardware_validation.launch.py
+++ b/launch/hardware_validation.launch.py
@@ -15,9 +15,39 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
+def _clean_namespace(value: str) -> str:
+    return value.strip().strip("/")
+
+
+def _normalize_prefix(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    if value != "/":
+        value = value.rstrip("/")
+    return value
+
+
+def _default_prefix(namespace: str, explicit_prefix: str, leaf: str) -> str:
+    explicit_prefix = _normalize_prefix(explicit_prefix)
+    if explicit_prefix:
+        return explicit_prefix
+    if namespace:
+        return f"/{namespace}/{leaf}"
+    return f"/{leaf}"
+
+
 def _build_control_actions(context, *args, **kwargs):
     del args, kwargs
     control_mode = LaunchConfiguration("control_mode").perform(context).strip().lower()
+    namespace = _clean_namespace(LaunchConfiguration("namespace").perform(context))
+    fmu_prefix = _default_prefix(
+        namespace, LaunchConfiguration("fmu_prefix").perform(context), "fmu"
+    )
+    controller_prefix = _default_prefix(
+        namespace, LaunchConfiguration("controller_prefix").perform(context), "cddp_mpc"
+    )
+    start_service = f"{controller_prefix}/start_mission"
     package_share = FindPackageShare("cddp_mpc").perform(context)
     offboard_launch = PathJoinSubstitution([package_share, "launch", "mpc_offboard.launch.py"])
 
@@ -27,12 +57,22 @@ def _build_control_actions(context, *args, **kwargs):
             LogInfo(
                 msg=(
                     "When ready, start the mission with: "
-                    "ros2 service call /cddp_mpc/start_mission std_srvs/srv/Trigger {}"
+                    f"ros2 service call {start_service} std_srvs/srv/Trigger {{}}"
                 )
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(offboard_launch),
-                launch_arguments={"params_file": LaunchConfiguration("params_file")}.items(),
+                launch_arguments={
+                    "params_file": LaunchConfiguration("params_file"),
+                    "namespace": LaunchConfiguration("namespace"),
+                    "fmu_prefix": fmu_prefix,
+                    "controller_prefix": controller_prefix,
+                    "visualizer_prefix": LaunchConfiguration("visualizer_prefix"),
+                    "target_system": LaunchConfiguration("target_system"),
+                    "target_component": LaunchConfiguration("target_component"),
+                    "source_system": LaunchConfiguration("source_system"),
+                    "source_component": LaunchConfiguration("source_component"),
+                }.items(),
             ),
         ]
 
@@ -57,11 +97,22 @@ def _build_validator_notice(context, *args, **kwargs):
     if launch_validator not in {"1", "true", "yes", "on"}:
         return []
 
+    namespace = _clean_namespace(LaunchConfiguration("namespace").perform(context))
+    fmu_prefix = _default_prefix(
+        namespace, LaunchConfiguration("fmu_prefix").perform(context), "fmu"
+    )
+    controller_prefix = _default_prefix(
+        namespace, LaunchConfiguration("controller_prefix").perform(context), "cddp_mpc"
+    )
     package_share = FindPackageShare("cddp_mpc").perform(context)
     validator_script = PathJoinSubstitution([package_share, "examples", "validate_takeoff_hover.py"])
     cmd = [
         "python3",
         validator_script,
+        "--fmu-prefix",
+        fmu_prefix,
+        "--controller-prefix",
+        controller_prefix,
         "--validation-mode",
         LaunchConfiguration("control_mode").perform(context),
         "--target-z",
@@ -124,6 +175,14 @@ def generate_launch_description():
                 default_value=default_params,
                 description="Path to the hardware ROS 2 parameter YAML for px4_mpc_node",
             ),
+            DeclareLaunchArgument("namespace", default_value=""),
+            DeclareLaunchArgument("fmu_prefix", default_value=""),
+            DeclareLaunchArgument("controller_prefix", default_value=""),
+            DeclareLaunchArgument("visualizer_prefix", default_value=""),
+            DeclareLaunchArgument("target_system", default_value="1"),
+            DeclareLaunchArgument("target_component", default_value="1"),
+            DeclareLaunchArgument("source_system", default_value="1"),
+            DeclareLaunchArgument("source_component", default_value="1"),
             DeclareLaunchArgument(
                 "control_mode",
                 default_value="offboard",

--- a/launch/mpc_offboard.launch.py
+++ b/launch/mpc_offboard.launch.py
@@ -71,6 +71,7 @@ def _rewrite_rviz_config(source_path: str, controller_prefix: str, visualizer_pr
     text = Path(source_path).read_text()
     text = text.replace("/cddp_mpc", controller_prefix)
     text = text.replace("/px4_visualizer", visualizer_prefix)
+    text = text.replace("/goal_pose", f"{controller_prefix}/goal_pose")
     stem = controller_prefix.strip("/").replace("/", "_") or "default"
     destination = Path(tempfile.gettempdir()) / f"cddp_mpc_{stem}_rviz.rviz"
     destination.write_text(text)

--- a/launch/mpc_offboard.launch.py
+++ b/launch/mpc_offboard.launch.py
@@ -2,11 +2,11 @@
 """Launch the cddp_mpc PX4 offboard MPC node with YAML parameters."""
 
 from pathlib import Path
+import tempfile
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess
-from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -23,9 +23,7 @@ def _resolve_default_params(package_name: str, filename: str):
             if candidate.is_file():
                 return str(candidate)
 
-    return PathJoinSubstitution(
-        [FindPackageShare(package_name), "config", filename]
-    )
+    return PathJoinSubstitution([FindPackageShare(package_name), "config", filename])
 
 
 def _resolve_share_file(package_name: str, directory: str, filename: str):
@@ -43,66 +41,182 @@ def _resolve_share_file(package_name: str, directory: str, filename: str):
     return PathJoinSubstitution([FindPackageShare(package_name), directory, filename])
 
 
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _clean_namespace(value: str) -> str:
+    return value.strip().strip("/")
+
+
+def _normalize_prefix(value: str) -> str:
+    value = value.strip()
+    if not value:
+        return ""
+    if value != "/":
+        value = value.rstrip("/")
+    return value
+
+
+def _default_prefix(namespace: str, explicit_prefix: str, leaf: str) -> str:
+    explicit_prefix = _normalize_prefix(explicit_prefix)
+    if explicit_prefix:
+        return explicit_prefix
+    if namespace:
+        return f"/{namespace}/{leaf}"
+    return f"/{leaf}"
+
+
+def _rewrite_rviz_config(source_path: str, controller_prefix: str, visualizer_prefix: str) -> str:
+    text = Path(source_path).read_text()
+    text = text.replace("/cddp_mpc", controller_prefix)
+    text = text.replace("/px4_visualizer", visualizer_prefix)
+    stem = controller_prefix.strip("/").replace("/", "_") or "default"
+    destination = Path(tempfile.gettempdir()) / f"cddp_mpc_{stem}_rviz.rviz"
+    destination.write_text(text)
+    return str(destination)
+
+
+def _build_actions(context, *args, **kwargs):
+    del args, kwargs
+    package_name = "cddp_mpc"
+    namespace = _clean_namespace(LaunchConfiguration("namespace").perform(context))
+    fmu_prefix = _default_prefix(
+        namespace, LaunchConfiguration("fmu_prefix").perform(context), "fmu"
+    )
+    controller_prefix = _default_prefix(
+        namespace, LaunchConfiguration("controller_prefix").perform(context), "cddp_mpc"
+    )
+    visualizer_prefix = _default_prefix(
+        namespace, LaunchConfiguration("visualizer_prefix").perform(context), "px4_visualizer"
+    )
+    params_overlay = LaunchConfiguration("params_overlay").perform(context).strip()
+    launch_visualizer = _as_bool(LaunchConfiguration("launch_visualizer").perform(context))
+    launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
+
+    controller_parameters = [LaunchConfiguration("params_file")]
+    if params_overlay:
+        controller_parameters.append(params_overlay)
+    controller_parameters.append(
+        {
+            "fmu_prefix": fmu_prefix,
+            "controller_prefix": controller_prefix,
+            "goal_pose_topic": f"{controller_prefix}/goal_pose",
+            "target_system": int(LaunchConfiguration("target_system").perform(context)),
+            "target_component": int(LaunchConfiguration("target_component").perform(context)),
+            "source_system": int(LaunchConfiguration("source_system").perform(context)),
+            "source_component": int(LaunchConfiguration("source_component").perform(context)),
+        }
+    )
+
+    actions = [
+        Node(
+            package=package_name,
+            executable="px4_mpc_node",
+            namespace=namespace,
+            name="cddp_mpc",
+            output="screen",
+            parameters=controller_parameters,
+        )
+    ]
+
+    if launch_visualizer or launch_rviz:
+        actions.append(
+            Node(
+                package=package_name,
+                executable="px4_visualizer",
+                namespace=namespace,
+                name="px4_visualizer",
+                output="screen",
+                parameters=[
+                    {
+                        "fmu_prefix": fmu_prefix,
+                        "controller_prefix": controller_prefix,
+                        "visualizer_prefix": visualizer_prefix,
+                    }
+                ],
+            )
+        )
+
+    if launch_rviz:
+        rviz_config = _rewrite_rviz_config(
+            LaunchConfiguration("rviz_config").perform(context),
+            controller_prefix,
+            visualizer_prefix,
+        )
+        actions.append(
+            ExecuteProcess(
+                cmd=["rviz2", "-d", rviz_config],
+                output="screen",
+                name=f"rviz2_{namespace or 'default'}",
+            )
+        )
+
+    return actions
+
+
 def generate_launch_description():
     package_name = "cddp_mpc"
     default_params = _resolve_default_params(package_name, "mpc_sitl.yaml")
     default_rviz_config = _resolve_share_file(package_name, "rviz", "px4_visualizer.rviz")
 
-    params_arg = DeclareLaunchArgument(
-        "params_file",
-        default_value=default_params,
-        description="Path to ROS 2 parameter YAML for the cddp_mpc node",
-    )
-    visualizer_arg = DeclareLaunchArgument(
-        "launch_visualizer",
-        default_value="false",
-        description="Launch the px4_visualizer ROS helper node.",
-    )
-    rviz_arg = DeclareLaunchArgument(
-        "launch_rviz",
-        default_value="false",
-        description="Launch RViz with the px4_visualizer display config.",
-    )
-    rviz_config_arg = DeclareLaunchArgument(
-        "rviz_config",
-        default_value=default_rviz_config,
-        description="Path to the RViz config used when launch_rviz is true.",
-    )
-
-    px4_mpc_node = Node(
-        package=package_name,
-        executable="px4_mpc_node",
-        name="cddp_mpc",
-        output="screen",
-        parameters=[LaunchConfiguration("params_file")],
-    )
-    px4_visualizer = Node(
-        package=package_name,
-        executable="px4_visualizer",
-        name="px4_visualizer",
-        output="screen",
-        condition=IfCondition(
-            PythonExpression(
-                [
-                    "'",
-                    LaunchConfiguration("launch_visualizer"),
-                    "'",
-                    " == 'true' or ",
-                    "'",
-                    LaunchConfiguration("launch_rviz"),
-                    "'",
-                    " == 'true'",
-                ]
-            )
-        ),
-    )
-    rviz = ExecuteProcess(
-        cmd=["rviz2", "-d", LaunchConfiguration("rviz_config")],
-        output="screen",
-        name="rviz2",
-        condition=IfCondition(LaunchConfiguration("launch_rviz")),
-    )
-
     return LaunchDescription(
-        [params_arg, visualizer_arg, rviz_arg, rviz_config_arg, px4_mpc_node, px4_visualizer, rviz]
+        [
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=default_params,
+                description="Path to ROS 2 parameter YAML for the cddp_mpc node",
+            ),
+            DeclareLaunchArgument(
+                "params_overlay",
+                default_value="",
+                description="Optional overlay parameter YAML applied after params_file.",
+            ),
+            DeclareLaunchArgument(
+                "namespace",
+                default_value="",
+                description="Optional ROS namespace for this controller instance.",
+            ),
+            DeclareLaunchArgument(
+                "fmu_prefix",
+                default_value="",
+                description="Override the PX4 topic prefix. Defaults to /<namespace>/fmu or /fmu.",
+            ),
+            DeclareLaunchArgument(
+                "controller_prefix",
+                default_value="",
+                description=(
+                    "Override the controller topic prefix. "
+                    "Defaults to /<namespace>/cddp_mpc or /cddp_mpc."
+                ),
+            ),
+            DeclareLaunchArgument(
+                "visualizer_prefix",
+                default_value="",
+                description=(
+                    "Override the visualizer topic prefix. "
+                    "Defaults to /<namespace>/px4_visualizer or /px4_visualizer."
+                ),
+            ),
+            DeclareLaunchArgument("target_system", default_value="1"),
+            DeclareLaunchArgument("target_component", default_value="1"),
+            DeclareLaunchArgument("source_system", default_value="1"),
+            DeclareLaunchArgument("source_component", default_value="1"),
+            DeclareLaunchArgument(
+                "launch_visualizer",
+                default_value="false",
+                description="Launch the px4_visualizer ROS helper node.",
+            ),
+            DeclareLaunchArgument(
+                "launch_rviz",
+                default_value="false",
+                description="Launch RViz with a prefix-adjusted px4_visualizer display config.",
+            ),
+            DeclareLaunchArgument(
+                "rviz_config",
+                default_value=default_rviz_config,
+                description="Path to the RViz config used when launch_rviz is true.",
+            ),
+            OpaqueFunction(function=_build_actions),
+        ]
     )

--- a/launch/multi_quadrotor_offboard.launch.py
+++ b/launch/multi_quadrotor_offboard.launch.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Launch multiple cddp_mpc offboard controller instances."""
+
+from pathlib import Path
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo, OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
+
+
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_actions(context, *args, **kwargs):
+    del args, kwargs
+    package_share = Path(FindPackageShare("cddp_mpc").perform(context))
+    offboard_launch = package_share / "launch" / "mpc_offboard.launch.py"
+    params_file = LaunchConfiguration("params_file").perform(context)
+    vehicle_count = int(LaunchConfiguration("vehicle_count").perform(context))
+    instance_start = int(LaunchConfiguration("instance_start").perform(context))
+    launch_visualizer = LaunchConfiguration("launch_visualizer").perform(context)
+    launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
+    rviz_instance = int(LaunchConfiguration("rviz_instance").perform(context))
+
+    actions = [
+        LogInfo(
+            msg=(
+                f"Launching {vehicle_count} offboard controller instances "
+                f"starting at PX4 instance {instance_start}."
+            )
+        )
+    ]
+
+    for offset in range(vehicle_count):
+        instance = instance_start + offset
+        namespace = f"px4_{instance}"
+        overlay_path = package_share / "config" / "fleet" / f"{namespace}.yaml"
+        actions.append(
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(str(offboard_launch)),
+                launch_arguments={
+                    "namespace": namespace,
+                    "params_file": params_file,
+                    "params_overlay": str(overlay_path) if overlay_path.is_file() else "",
+                    "fmu_prefix": f"/{namespace}/fmu",
+                    "controller_prefix": f"/{namespace}/cddp_mpc",
+                    "visualizer_prefix": f"/{namespace}/px4_visualizer",
+                    "target_system": str(instance + 1),
+                    "target_component": "1",
+                    "source_system": str(instance + 1),
+                    "source_component": "1",
+                    "launch_visualizer": launch_visualizer,
+                    "launch_rviz": "true" if launch_rviz and instance == rviz_instance else "false",
+                }.items(),
+            )
+        )
+
+    return actions
+
+
+def generate_launch_description():
+    package_share = FindPackageShare("cddp_mpc")
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "params_file",
+                default_value=PathJoinSubstitution([package_share, "config", "mpc_sitl.yaml"]),
+                description="Base parameter YAML shared by all controller instances.",
+            ),
+            DeclareLaunchArgument("vehicle_count", default_value="2"),
+            DeclareLaunchArgument("instance_start", default_value="0"),
+            DeclareLaunchArgument("launch_visualizer", default_value="false"),
+            DeclareLaunchArgument("launch_rviz", default_value="false"),
+            DeclareLaunchArgument("rviz_instance", default_value="0"),
+            OpaqueFunction(function=_build_actions),
+        ]
+    )

--- a/launch/multi_quadrotor_offboard.launch.py
+++ b/launch/multi_quadrotor_offboard.launch.py
@@ -2,6 +2,7 @@
 """Launch multiple cddp_mpc offboard controller instances."""
 
 from pathlib import Path
+import tempfile
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, LogInfo, OpaqueFunction
@@ -14,6 +15,25 @@ def _as_bool(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _write_generated_overlay(namespace: str, target_y_m: float) -> str:
+    overlay_path = Path(tempfile.gettempdir()) / f"cddp_mpc_{namespace}_fleet_overlay.yaml"
+    overlay_path.write_text(
+        "\n".join(
+            [
+                "cddp_mpc:",
+                "  ros__parameters:",
+                f"    teleop_topic: /{namespace}/teleop/cmd_vel",
+                f"    joy_topic: /{namespace}/joy",
+                f"    goal_pose_topic: /{namespace}/cddp_mpc/goal_pose",
+                "    target_x_m: 0.0",
+                f"    target_y_m: {target_y_m:.3f}",
+            ]
+        )
+        + "\n"
+    )
+    return str(overlay_path)
+
+
 def _build_actions(context, *args, **kwargs):
     del args, kwargs
     package_share = Path(FindPackageShare("cddp_mpc").perform(context))
@@ -21,6 +41,7 @@ def _build_actions(context, *args, **kwargs):
     params_file = LaunchConfiguration("params_file").perform(context)
     vehicle_count = int(LaunchConfiguration("vehicle_count").perform(context))
     instance_start = int(LaunchConfiguration("instance_start").perform(context))
+    instance_spacing_m = float(LaunchConfiguration("instance_spacing_m").perform(context))
     launch_visualizer = LaunchConfiguration("launch_visualizer").perform(context)
     launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
     rviz_instance = int(LaunchConfiguration("rviz_instance").perform(context))
@@ -38,13 +59,18 @@ def _build_actions(context, *args, **kwargs):
         instance = instance_start + offset
         namespace = f"px4_{instance}"
         overlay_path = package_share / "config" / "fleet" / f"{namespace}.yaml"
+        params_overlay = (
+            str(overlay_path)
+            if overlay_path.is_file()
+            else _write_generated_overlay(namespace, offset * instance_spacing_m)
+        )
         actions.append(
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(str(offboard_launch)),
                 launch_arguments={
                     "namespace": namespace,
                     "params_file": params_file,
-                    "params_overlay": str(overlay_path) if overlay_path.is_file() else "",
+                    "params_overlay": params_overlay,
                     "fmu_prefix": f"/{namespace}/fmu",
                     "controller_prefix": f"/{namespace}/cddp_mpc",
                     "visualizer_prefix": f"/{namespace}/px4_visualizer",
@@ -72,6 +98,7 @@ def generate_launch_description():
             ),
             DeclareLaunchArgument("vehicle_count", default_value="2"),
             DeclareLaunchArgument("instance_start", default_value="0"),
+            DeclareLaunchArgument("instance_spacing_m", default_value="2.0"),
             DeclareLaunchArgument("launch_visualizer", default_value="false"),
             DeclareLaunchArgument("launch_rviz", default_value="false"),
             DeclareLaunchArgument("rviz_instance", default_value="0"),

--- a/launch/multi_quadrotor_simulation.launch.py
+++ b/launch/multi_quadrotor_simulation.launch.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Launch multiple PX4 SITL instances with Gazebo and optional visualizers."""
+
+from pathlib import Path
+import tempfile
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, LogInfo, OpaqueFunction
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def _as_bool(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _rewrite_rviz_config(source_path: str, controller_prefix: str, visualizer_prefix: str) -> str:
+    text = Path(source_path).read_text()
+    text = text.replace("/cddp_mpc", controller_prefix)
+    text = text.replace("/px4_visualizer", visualizer_prefix)
+    stem = controller_prefix.strip("/").replace("/", "_") or "default"
+    destination = Path(tempfile.gettempdir()) / f"cddp_mpc_{stem}_rviz.rviz"
+    destination.write_text(text)
+    return str(destination)
+
+
+def _build_actions(context, *args, **kwargs):
+    del args, kwargs
+    px4_root = Path(LaunchConfiguration("px4_root").perform(context))
+    px4_bin = px4_root / "build" / "px4_sitl_default" / "bin" / "px4"
+    vehicle = LaunchConfiguration("vehicle").perform(context)
+    world = LaunchConfiguration("world").perform(context)
+    px4_autostart = LaunchConfiguration("px4_autostart").perform(context)
+    vehicle_count = int(LaunchConfiguration("vehicle_count").perform(context))
+    instance_start = int(LaunchConfiguration("instance_start").perform(context))
+    instance_spacing_m = float(LaunchConfiguration("instance_spacing_m").perform(context))
+    launch_visualizer = _as_bool(LaunchConfiguration("launch_visualizer").perform(context))
+    launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
+    rviz_instance = int(LaunchConfiguration("rviz_instance").perform(context))
+
+    actions = [
+        LogInfo(
+            msg=(
+                f"Starting {vehicle_count} PX4 SITL instances from {px4_bin} "
+                f"with world='{world}' and vehicle='{vehicle}'."
+            )
+        ),
+        ExecuteProcess(
+            cmd=["MicroXRCEAgent", "udp4", "-p", "8888"],
+            output="screen",
+            name="micro_xrce_dds_agent",
+        ),
+    ]
+
+    for offset in range(vehicle_count):
+        instance = instance_start + offset
+        namespace = f"px4_{instance}"
+        env = {
+            "PX4_GZ_WORLD": world,
+            "PX4_SIM_MODEL": vehicle,
+            "PX4_SYS_AUTOSTART": px4_autostart,
+            "PX4_UXRCE_DDS_NS": namespace,
+        }
+        if offset > 0:
+            env["PX4_GZ_STANDALONE"] = "1"
+            env["PX4_GZ_MODEL_POSE"] = f"0,{offset * instance_spacing_m:.3f},0"
+
+        actions.append(
+            ExecuteProcess(
+                cmd=[str(px4_bin), "-i", str(instance)],
+                cwd=str(px4_root),
+                additional_env=env,
+                output="screen",
+                name=f"px4_sitl_{namespace}",
+            )
+        )
+
+        if launch_visualizer or (launch_rviz and instance == rviz_instance):
+            actions.append(
+                Node(
+                    package="cddp_mpc",
+                    executable="px4_visualizer",
+                    namespace=namespace,
+                    name="px4_visualizer",
+                    output="screen",
+                    parameters=[
+                        {
+                            "fmu_prefix": f"/{namespace}/fmu",
+                            "controller_prefix": f"/{namespace}/cddp_mpc",
+                            "visualizer_prefix": f"/{namespace}/px4_visualizer",
+                        }
+                    ],
+                )
+            )
+
+        if launch_rviz and instance == rviz_instance:
+            rviz_config = _rewrite_rviz_config(
+                LaunchConfiguration("rviz_config").perform(context),
+                f"/{namespace}/cddp_mpc",
+                f"/{namespace}/px4_visualizer",
+            )
+            actions.append(
+                ExecuteProcess(
+                    cmd=["rviz2", "-d", rviz_config],
+                    output="screen",
+                    name=f"rviz2_{namespace}",
+                )
+            )
+
+    return actions
+
+
+def generate_launch_description():
+    package_share = FindPackageShare("cddp_mpc")
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument("px4_root", default_value="/opt/PX4-Autopilot"),
+            DeclareLaunchArgument("vehicle", default_value="gz_x500"),
+            DeclareLaunchArgument("world", default_value="default"),
+            DeclareLaunchArgument("px4_autostart", default_value="4001"),
+            DeclareLaunchArgument("vehicle_count", default_value="2"),
+            DeclareLaunchArgument("instance_start", default_value="0"),
+            DeclareLaunchArgument("instance_spacing_m", default_value="2.0"),
+            DeclareLaunchArgument("launch_visualizer", default_value="false"),
+            DeclareLaunchArgument("launch_rviz", default_value="false"),
+            DeclareLaunchArgument("rviz_instance", default_value="0"),
+            DeclareLaunchArgument(
+                "rviz_config",
+                default_value=PathJoinSubstitution([package_share, "rviz", "px4_visualizer.rviz"]),
+            ),
+            OpaqueFunction(function=_build_actions),
+        ]
+    )

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,9 @@
   <depend>rclpy</depend>
   <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
+  <depend>interactive_markers</depend>
   <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
   <depend>px4_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/src/px4_mpc_node.cpp
+++ b/src/px4_mpc_node.cpp
@@ -3,14 +3,15 @@
 #include <cinttypes>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
 #include <cstdint>
-#include <future>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -18,6 +19,9 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <diagnostic_msgs/msg/key_value.hpp>
 #include <Eigen/Dense>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <nav_msgs/msg/path.hpp>
 #include <px4_msgs/msg/offboard_control_mode.hpp>
 #include <px4_msgs/msg/vehicle_attitude.hpp>
 #include <px4_msgs/msg/vehicle_command.hpp>
@@ -33,13 +37,16 @@
 #define CDDP_MPC_HAS_VEHICLE_ANGULAR_VELOCITY 0
 #endif
 #include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
 #include <std_srvs/srv/trigger.hpp>
+#include <visualization_msgs/msg/marker.hpp>
 
 #include "cddp.hpp"
 #include "cddp_mpc/controller_logic.hpp"
 #include "cddp_mpc/error_state_quadrotor_thrust.hpp"
 #include "cddp_mpc/indi_rotational_compensator.hpp"
 #include "cddp_mpc/px4_utils.hpp"
+#include "cddp_mpc/reference_manager.hpp"
 #include "cddp_mpc/reference_provider.hpp"
 #include "cddp_mpc/thrust_allocation_constraint.hpp"
 
@@ -62,6 +69,11 @@ using diagnostic_msgs::msg::DiagnosticArray;
 using diagnostic_msgs::msg::DiagnosticStatus;
 using diagnostic_msgs::msg::KeyValue;
 using cddp_mpc::ReferenceTrajectory;
+using geometry_msgs::msg::PoseStamped;
+using geometry_msgs::msg::TwistStamped;
+using nav_msgs::msg::Path;
+using sensor_msgs::msg::Joy;
+using visualization_msgs::msg::Marker;
 
 std::string formatDouble(double value, int precision = 3) {
   if (!std::isfinite(value)) {
@@ -72,6 +84,42 @@ std::string formatDouble(double value, int precision = 3) {
   stream.precision(precision);
   stream << value;
   return stream.str();
+}
+
+std::string trimTrailingSlashes(std::string value) {
+  while (value.size() > 1 && value.back() == '/') {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::string topicFromPrefix(const std::string &prefix, const std::string &suffix) {
+  const std::string normalized_prefix = trimTrailingSlashes(prefix);
+  if (normalized_prefix.empty()) {
+    return suffix;
+  }
+  if (normalized_prefix == "/") {
+    return "/" + suffix;
+  }
+  return normalized_prefix + "/" + suffix;
+}
+
+double wrapAngle(double angle_rad) {
+  constexpr double kPi = 3.14159265358979323846;
+  while (angle_rad > kPi) {
+    angle_rad -= 2.0 * kPi;
+  }
+  while (angle_rad < -kPi) {
+    angle_rad += 2.0 * kPi;
+  }
+  return angle_rad;
+}
+
+double yawFromQuaternionEnu(const Eigen::Quaterniond &q_enu) {
+  const double siny_cosp = 2.0 * (q_enu.w() * q_enu.z() + q_enu.x() * q_enu.y());
+  const double cosy_cosp =
+      1.0 - 2.0 * (q_enu.y() * q_enu.y() + q_enu.z() * q_enu.z());
+  return std::atan2(siny_cosp, cosy_cosp);
 }
 
 struct SolveResult {
@@ -93,11 +141,23 @@ struct SolveResult {
   std::vector<Eigen::VectorXd> control_trajectory;
 };
 
-struct PendingSolve {
+struct SolverRequest {
   std::uint64_t request_id{0};
+  double enqueue_time_s{0.0};
+  Eigen::VectorXd initial_state;
+  ReferenceTrajectory reference_trajectory;
+  std::vector<Eigen::VectorXd> initial_state_guess;
+  std::vector<Eigen::VectorXd> initial_control_guess;
+  Eigen::Vector3d reference_target_enu{Eigen::Vector3d::Zero()};
+  bool landing_mode{false};
+};
+
+struct CompletedSolve {
   double start_time_s{0.0};
-  bool timeout_reported{false};
-  std::future<SolveResult> future;
+  double completion_time_s{0.0};
+  bool overran_budget{false};
+  Eigen::Vector3d reference_target_enu{Eigen::Vector3d::Zero()};
+  SolveResult result;
 };
 
 struct SafetyTrace {
@@ -121,6 +181,37 @@ public:
         reference_controls_(std::move(reference_controls)) {
     reference_state_ = reference_state;
     reference_states_ = std::move(reference_states);
+  }
+
+  void setReferenceState(const Eigen::VectorXd &reference_state) override {
+    reference_state_ = reference_state;
+    if (reference_states_.empty()) {
+      reference_states_.push_back(reference_state_);
+    } else {
+      reference_states_.back() = reference_state_;
+    }
+  }
+
+  void setReferenceStates(
+      const std::vector<Eigen::VectorXd> &reference_states) override {
+    reference_states_ = reference_states;
+    if (!reference_states_.empty()) {
+      reference_state_ = reference_states_.back();
+    }
+  }
+
+  void setReferenceControls(std::vector<Eigen::VectorXd> reference_controls) {
+    reference_controls_ = std::move(reference_controls);
+    if (!reference_controls_.empty()) {
+      default_control_ = reference_controls_.front();
+    }
+  }
+
+  void setReferenceTrajectory(
+      const std::vector<Eigen::VectorXd> &reference_states,
+      std::vector<Eigen::VectorXd> reference_controls) {
+    setReferenceStates(reference_states);
+    setReferenceControls(std::move(reference_controls));
   }
 
   double evaluate(const std::vector<Eigen::VectorXd> &states,
@@ -197,6 +288,9 @@ private:
   }
 
   const Eigen::VectorXd &referenceControlAt(int index) const {
+    if (reference_controls_.empty()) {
+      return default_control_;
+    }
     const std::size_t clamped_index = static_cast<std::size_t>(
         std::clamp(index, 0, static_cast<int>(reference_controls_.size() - 1)));
     return reference_controls_[clamped_index];
@@ -207,6 +301,7 @@ private:
   Eigen::MatrixXd Qf_;
   double timestep_{0.1};
   std::vector<Eigen::VectorXd> reference_controls_;
+  Eigen::VectorXd default_control_{Eigen::VectorXd::Zero(4)};
 };
 
 class PX4MPCNode : public rclcpp::Node {
@@ -223,6 +318,8 @@ public:
     hover_thrust_n_ = hover_thrust_n_ > 0.0 ? hover_thrust_n_ : mass_kg_ * gravity_mps2_;
     reference_provider_ = std::make_unique<cddp_mpc::PositionYawReferenceProvider>(
         buildReferenceConfig());
+    reference_manager_ = std::make_unique<cddp_mpc::ReferenceManager>(
+        buildReferenceManagerConfig());
     rotational_indi_ =
         std::make_unique<cddp_mpc::IndiRotationalCompensator>(inertiaMatrix());
     rotational_indi_->setConfig(buildIndiConfig());
@@ -236,36 +333,53 @@ public:
     auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).best_effort();
 
     local_position_sub_ = create_subscription<VehicleLocalPosition>(
-        "/fmu/out/vehicle_local_position", qos,
+        local_position_topic_, qos,
         std::bind(&PX4MPCNode::localPositionCallback, this, std::placeholders::_1));
     odometry_sub_ = create_subscription<VehicleOdometry>(
-        "/fmu/out/vehicle_odometry", qos,
+        odometry_topic_, qos,
         std::bind(&PX4MPCNode::odometryCallback, this, std::placeholders::_1));
     attitude_sub_ = create_subscription<VehicleAttitude>(
-        "/fmu/out/vehicle_attitude", qos,
+        attitude_topic_, qos,
         std::bind(&PX4MPCNode::attitudeCallback, this, std::placeholders::_1));
     vehicle_status_sub_ = create_subscription<VehicleStatus>(
-        "/fmu/out/vehicle_status", qos,
+        vehicle_status_topic_, qos,
         std::bind(&PX4MPCNode::vehicleStatusCallback, this, std::placeholders::_1));
+    teleop_sub_ = create_subscription<TwistStamped>(
+        teleop_topic_, rclcpp::QoS(10),
+        std::bind(&PX4MPCNode::teleopCallback, this, std::placeholders::_1));
+    joy_sub_ = create_subscription<Joy>(
+        joy_topic_, rclcpp::QoS(10),
+        std::bind(&PX4MPCNode::joyCallback, this, std::placeholders::_1));
+    goal_pose_sub_ = create_subscription<PoseStamped>(
+        goal_pose_topic_, rclcpp::QoS(10),
+        std::bind(&PX4MPCNode::goalPoseCallback, this, std::placeholders::_1));
 #if CDDP_MPC_HAS_VEHICLE_ANGULAR_VELOCITY
     angular_velocity_sub_ = create_subscription<VehicleAngularVelocity>(
-        "/fmu/out/vehicle_angular_velocity", qos,
+        angular_velocity_topic_, qos,
         std::bind(&PX4MPCNode::angularVelocityCallback, this, std::placeholders::_1));
 #endif
 
     offboard_mode_pub_ = create_publisher<OffboardControlMode>(
-        "/fmu/in/offboard_control_mode", qos);
+        offboard_control_mode_topic_, qos);
     vehicle_thrust_pub_ = create_publisher<VehicleThrustSetpoint>(
-        "/fmu/in/vehicle_thrust_setpoint", qos);
+        vehicle_thrust_setpoint_topic_, qos);
     vehicle_torque_pub_ = create_publisher<VehicleTorqueSetpoint>(
-        "/fmu/in/vehicle_torque_setpoint", qos);
+        vehicle_torque_setpoint_topic_, qos);
     vehicle_command_pub_ = create_publisher<VehicleCommand>(
-        "/fmu/in/vehicle_command", qos);
+        vehicle_command_topic_, qos);
     diagnostic_pub_ =
-        create_publisher<DiagnosticArray>("/cddp_mpc/status", rclcpp::QoS(10));
+        create_publisher<DiagnosticArray>(status_topic_, rclcpp::QoS(10));
+    active_goal_pub_ =
+        create_publisher<PoseStamped>(active_goal_topic_, rclcpp::QoS(10));
+    predicted_path_pub_ =
+        create_publisher<Path>(predicted_path_topic_, rclcpp::QoS(10));
+    geofence_marker_pub_ =
+        create_publisher<Marker>(geofence_topic_, rclcpp::QoS(10));
+    safety_text_pub_ =
+        create_publisher<Marker>(safety_text_topic_, rclcpp::QoS(10));
 
     start_mission_service_ = create_service<std_srvs::srv::Trigger>(
-        "/cddp_mpc/start_mission",
+        start_mission_service_name_,
         std::bind(&PX4MPCNode::handleStartMission, this, std::placeholders::_1,
                   std::placeholders::_2));
 
@@ -277,14 +391,18 @@ public:
         std::bind(&PX4MPCNode::solveLoop, this));
     offboard_timer_ = create_wall_timer(
         100ms, std::bind(&PX4MPCNode::publishOffboardControlMode, this));
+    solver_thread_ = std::thread(&PX4MPCNode::solverWorkerLoop, this);
 
     RCLCPP_INFO(get_logger(),
                 "Initialized PX4 CDDP MPC node (control=%.1f Hz, solve=%.1f Hz, "
-                "horizon=%d, dt=%.3f s)",
-                control_rate_hz_, solve_rate_hz_, horizon_steps_, mpc_dt_);
+                "horizon=%d, dt=%.3f s, fmu_prefix=%s, controller_prefix=%s, "
+                "target_system=%d)",
+                control_rate_hz_, solve_rate_hz_, horizon_steps_, mpc_dt_,
+                fmu_prefix_.c_str(), controller_prefix_.c_str(), target_system_);
     if (!auto_start_sequence_) {
       RCLCPP_INFO(get_logger(),
-                  "Mission start is gated. Call /cddp_mpc/start_mission to begin.");
+                  "Mission start is gated. Call %s to begin.",
+                  start_mission_service_name_.c_str());
     }
     if (indi_use_rpm_feedback_) {
       RCLCPP_WARN(get_logger(),
@@ -293,10 +411,53 @@ public:
     }
   }
 
+  ~PX4MPCNode() override { stopSolverWorker(); }
+
 private:
   void loadParameters() {
+    fmu_prefix_ = trimTrailingSlashes(declareOrGet("fmu_prefix", std::string("/fmu")));
+    controller_prefix_ = trimTrailingSlashes(
+        declareOrGet("controller_prefix", std::string("/cddp_mpc")));
+    target_system_ = declareOrGet("target_system", 1);
+    target_component_ = declareOrGet("target_component", 1);
+    source_system_ = declareOrGet("source_system", 1);
+    source_component_ = declareOrGet("source_component", 1);
+
+    local_position_topic_ = declareOrGet(
+        "local_position_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_local_position"));
+    odometry_topic_ =
+        declareOrGet("odometry_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_odometry"));
+    attitude_topic_ =
+        declareOrGet("attitude_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_attitude"));
+    vehicle_status_topic_ = declareOrGet(
+        "vehicle_status_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_status"));
+    angular_velocity_topic_ = declareOrGet(
+        "angular_velocity_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_angular_velocity"));
+    offboard_control_mode_topic_ = declareOrGet(
+        "offboard_control_mode_topic", topicFromPrefix(fmu_prefix_, "in/offboard_control_mode"));
+    vehicle_thrust_setpoint_topic_ = declareOrGet(
+        "vehicle_thrust_setpoint_topic",
+        topicFromPrefix(fmu_prefix_, "in/vehicle_thrust_setpoint"));
+    vehicle_torque_setpoint_topic_ = declareOrGet(
+        "vehicle_torque_setpoint_topic",
+        topicFromPrefix(fmu_prefix_, "in/vehicle_torque_setpoint"));
+    vehicle_command_topic_ = declareOrGet(
+        "vehicle_command_topic", topicFromPrefix(fmu_prefix_, "in/vehicle_command"));
+    status_topic_ =
+        declareOrGet("status_topic", topicFromPrefix(controller_prefix_, "status"));
+    active_goal_topic_ =
+        declareOrGet("active_goal_topic", topicFromPrefix(controller_prefix_, "active_goal"));
+    predicted_path_topic_ = declareOrGet(
+        "predicted_path_topic", topicFromPrefix(controller_prefix_, "predicted_path"));
+    geofence_topic_ =
+        declareOrGet("geofence_topic", topicFromPrefix(controller_prefix_, "geofence"));
+    safety_text_topic_ =
+        declareOrGet("safety_text_topic", topicFromPrefix(controller_prefix_, "safety_text"));
+    start_mission_service_name_ = declareOrGet(
+        "start_mission_service", topicFromPrefix(controller_prefix_, "start_mission"));
+
     control_rate_hz_ = declareOrGet("control_rate_hz", 100.0);
-    solve_rate_hz_ = declareOrGet("solve_rate_hz", 20.0);
+    solve_rate_hz_ = declareOrGet("solve_rate_hz", 25.0);
     mpc_dt_ = declareOrGet("mpc_dt", 0.05);
     horizon_steps_ = declareOrGet("horizon_steps", 20);
     stale_plan_timeout_s_ = declareOrGet("stale_plan_timeout_s", 0.25);
@@ -371,6 +532,10 @@ private:
         declareOrGet("reference_max_climb_rate_mps", 1.0);
     reference_max_climb_accel_mps2_ =
         declareOrGet("reference_max_climb_accel_mps2", 1.5);
+    reference_max_xy_speed_mps_ =
+        declareOrGet("reference_max_xy_speed_mps", reference_max_climb_rate_mps_);
+    reference_max_xy_accel_mps2_ =
+        declareOrGet("reference_max_xy_accel_mps2", reference_max_climb_accel_mps2_);
     reference_smoothing_tau_s_ =
         declareOrGet("reference_smoothing_tau_s", 0.6);
     reference_mode_ = declareOrGet("reference_mode", std::string("active_setpoint"));
@@ -389,6 +554,24 @@ private:
     target_x_m_ = declareOrGet("target_x_m", 0.0);
     target_y_m_ = declareOrGet("target_y_m", 0.0);
     target_z_m_ = declareOrGet("target_z_m", -3.0);
+    teleop_topic_ = declareOrGet("teleop_topic", std::string("/teleop/cmd_vel"));
+    joy_topic_ = declareOrGet("joy_topic", std::string("/joy"));
+    teleop_frame_ = declareOrGet("teleop_frame", std::string("body"));
+    teleop_timeout_s_ = declareOrGet("teleop_timeout_s", 0.2);
+    teleop_require_deadman_ = declareOrGet("teleop_require_deadman", true);
+    teleop_deadman_button_index_ = declareOrGet("teleop_deadman_button_index", 4);
+    teleop_max_xy_speed_mps_ = declareOrGet("teleop_max_xy_speed_mps", 1.0);
+    teleop_max_z_speed_mps_ = declareOrGet("teleop_max_z_speed_mps", 0.6);
+    teleop_max_yaw_rate_rad_s_ =
+        declareOrGet("teleop_max_yaw_rate_rad_s", 0.8);
+    goal_pose_topic_ =
+        declareOrGet("goal_pose_topic", topicFromPrefix(controller_prefix_, "goal_pose"));
+    goal_pose_frame_ = declareOrGet("goal_pose_frame", std::string("map"));
+    goal_timeout_s_ = declareOrGet("goal_timeout_s", 1.0);
+    geofence_half_extent_x_m_ = declareOrGet("geofence_half_extent_x_m", 5.0);
+    geofence_half_extent_y_m_ = declareOrGet("geofence_half_extent_y_m", 5.0);
+    geofence_min_z_m_ = declareOrGet("geofence_min_z_m", 0.0);
+    geofence_max_z_m_ = declareOrGet("geofence_max_z_m", 5.0);
     odom_frame_config_.quaternion_order =
         declareOrGet("odom_quaternion_order", std::string("auto"));
     odom_frame_config_.odom_body_frame =
@@ -414,8 +597,11 @@ private:
     terminal_tilt_weight_ = declareOrGet("terminal_tilt_weight", 6.0);
 
     max_iterations_ = declareOrGet("max_iterations", 8);
+    realtime_mode_ = declareOrGet("realtime_mode", true);
+    rti_max_iterations_ = declareOrGet("rti_max_iterations", 5);
     constraint_tolerance_ = declareOrGet("constraint_tolerance", 0.5);
     solve_timeout_ms_ = declareOrGet("solve_timeout_ms", 450.0);
+    solve_budget_ms_ = declareOrGet("solve_budget_ms", solve_timeout_ms_);
     max_pending_solve_requests_ = static_cast<std::size_t>(
         std::max(1, declareOrGet("max_pending_solve_requests", 2)));
     takeoff_min_thrust_margin_n_ =
@@ -580,6 +766,49 @@ private:
         msg->nav_state == VehicleStatus::NAVIGATION_STATE_OFFBOARD;
   }
 
+  void teleopCallback(const TwistStamped::SharedPtr msg) {
+    if (!reference_manager_) {
+      return;
+    }
+    Eigen::Vector3d linear_velocity(msg->twist.linear.x, msg->twist.linear.y,
+                                    msg->twist.linear.z);
+    reference_manager_->updateTeleopCommand(
+        nowSeconds(), linear_velocity, msg->twist.angular.z,
+        teleop_frame_ == "world" ? cddp_mpc::TeleopFrame::World
+                                  : cddp_mpc::TeleopFrame::Body);
+  }
+
+  void joyCallback(const Joy::SharedPtr msg) {
+    if (!reference_manager_) {
+      return;
+    }
+    const bool deadman_pressed =
+        teleop_deadman_button_index_ >= 0 &&
+        teleop_deadman_button_index_ < static_cast<int>(msg->buttons.size()) &&
+        msg->buttons[static_cast<std::size_t>(teleop_deadman_button_index_)] != 0;
+    reference_manager_->updateDeadmanState(nowSeconds(), deadman_pressed);
+  }
+
+  void goalPoseCallback(const PoseStamped::SharedPtr msg) {
+    if (!reference_manager_) {
+      return;
+    }
+    if (!msg->header.frame_id.empty() && msg->header.frame_id != goal_pose_frame_) {
+      RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 2000,
+          "Ignoring goal pose in unexpected frame '%s' (expected '%s').",
+          msg->header.frame_id.c_str(), goal_pose_frame_.c_str());
+      return;
+    }
+    const Eigen::Quaterniond orientation(
+        msg->pose.orientation.w, msg->pose.orientation.x, msg->pose.orientation.y,
+        msg->pose.orientation.z);
+    const Eigen::Vector3d position(msg->pose.position.x, msg->pose.position.y,
+                                   msg->pose.position.z);
+    reference_manager_->updateGoalPose(nowSeconds(), position,
+                                       yawFromQuaternionEnu(orientation));
+  }
+
   void handleStartMission(
       const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
       std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
@@ -587,7 +816,8 @@ private:
     mode_request_time_ = nowSeconds();
     response->success = true;
     response->message = "mission start requested";
-    RCLCPP_INFO(get_logger(), "Mission start requested via /cddp_mpc/start_mission.");
+    RCLCPP_INFO(get_logger(), "Mission start requested via %s.",
+                start_mission_service_name_.c_str());
   }
 
   void controlLoop() {
@@ -601,6 +831,7 @@ private:
     }
 
     updateMode();
+    updateReferenceManager();
     pollSolveResult();
 
     SafetyTrace trace{};
@@ -629,6 +860,7 @@ private:
     last_published_command_ = command;
     publishVehicleThrustTorqueSetpoint(command);
     publishStatusDiagnostics();
+    publishReferenceVisualization();
     debugLog(command);
   }
 
@@ -641,24 +873,6 @@ private:
     }
 
     pollSolveResult();
-    bool has_fresh_request = false;
-    for (auto &pending : pending_solves_) {
-      const double age_ms = (nowSeconds() - pending.start_time_s) * 1000.0;
-      if (age_ms <= solve_timeout_ms_) {
-        has_fresh_request = true;
-      } else if (!pending.timeout_reported) {
-        pending.timeout_reported = true;
-        RCLCPP_WARN(get_logger(),
-                    "CDDP solve request %" PRIu64
-                    " exceeded timeout budget (%.1f ms > %.1f ms). "
-                    "Launching a fresher request if capacity allows.",
-                    pending.request_id, age_ms, solve_timeout_ms_);
-      }
-    }
-    if (has_fresh_request || pending_solves_.size() >= max_pending_solve_requests_) {
-      return;
-    }
-
     if (!(armed_ && offboard_enabled_)) {
       return;
     }
@@ -684,19 +898,14 @@ private:
     }
 
     const std::uint64_t request_id = ++next_solve_request_id_;
-    pending_solves_.push_back(PendingSolve{
-        request_id,
-        nowSeconds(),
-        false,
-        std::async(std::launch::async,
-                   [this, request_id, initial_state, reference_trajectory,
-                    initial_state_guess, initial_control_guess, landing_mode,
-                    reference_target_enu]() {
-                     return solveMPC(request_id, initial_state, reference_trajectory,
-                                     initial_state_guess, initial_control_guess,
-                                     reference_target_enu, landing_mode);
-                   }),
-    });
+    queueSolveRequest(SolverRequest{request_id,
+                                    nowSeconds(),
+                                    initial_state,
+                                    reference_trajectory,
+                                    initial_state_guess,
+                                    initial_control_guess,
+                                    reference_target_enu,
+                                    landing_mode});
   }
 
   void updateMode() {
@@ -829,13 +1038,16 @@ private:
     result.command = hoverCommand(landing_mode ? landing_descent_rate_mps_ : 0.0);
 
     try {
-      auto solver = createSolver(reference_trajectory, reference_target_enu);
-      solver->setInitialState(initial_state);
-      solver->setReferenceState(reference_trajectory.states.back());
-      solver->setReferenceStates(reference_trajectory.states);
-      solver->setInitialTrajectory(initial_state_guess, initial_control_guess);
+      configureSolverBackend(SolverRequest{request_id,
+                                           0.0,
+                                           initial_state,
+                                           reference_trajectory,
+                                           initial_state_guess,
+                                           initial_control_guess,
+                                           reference_target_enu,
+                                           landing_mode});
 
-      const cddp::CDDPSolution solution = solver->solve(solver_type_);
+      const cddp::CDDPSolution solution = solver_backend_->solve(solver_type_);
       result.status_message = solution.status_message;
       result.converged = solution.status_message == "OptimalSolutionFound" ||
                          solution.status_message == "AcceptableSolutionFound";
@@ -901,11 +1113,35 @@ private:
     return result;
   }
 
-  std::unique_ptr<cddp::CDDP> createSolver(
-      const ReferenceTrajectory &reference_trajectory,
-      const Eigen::Vector3d &setpoint_enu) const {
+  cddp::CDDPOptions buildSolverOptions() const {
+    cddp::CDDPOptions options;
+    const int effective_max_iterations =
+        realtime_mode_ ? std::min(std::max(1, max_iterations_),
+                                  std::max(1, rti_max_iterations_))
+                       : std::max(1, max_iterations_);
+    options.max_iterations = effective_max_iterations;
+    options.tolerance = 1e-4;
+    options.acceptable_tolerance = 1e-3;
+    options.max_cpu_time = solve_budget_ms_ / 1000.0;
+    options.verbose = false;
+    options.debug = false;
+    options.print_solver_header = false;
+    options.warm_start = true;
+    options.regularization.initial_value = 1e-3;
+    options.msipddp.segment_length = std::max(1, horizon_steps_ / 4);
+    options.msipddp.rollout_type = "nonlinear";
+    return options;
+  }
+
+  void initializeSolverBackend(const ReferenceTrajectory &reference_trajectory,
+                               const Eigen::Vector3d &setpoint_enu) {
+    if (solver_backend_) {
+      return;
+    }
+
     auto system = std::make_unique<cddp_mpc::ErrorStateEnuQuadrotorThrust>(
         mpc_dt_, mass_kg_, inertiaMatrix(), arm_length_m_, setpoint_enu, "rk4");
+    solver_system_ = system.get();
 
     const int state_dim = 13;
     const int control_dim = 4;
@@ -936,23 +1172,12 @@ private:
     auto objective = std::make_unique<TrackingQuadraticObjective>(
         Q, R, Qf, reference_trajectory.states.back(), reference_trajectory.states,
         reference_trajectory.controls, mpc_dt_);
+    solver_objective_ = objective.get();
 
-    cddp::CDDPOptions options;
-    options.max_iterations = std::max(1, max_iterations_);
-    options.tolerance = 1e-4;
-    options.acceptable_tolerance = 1e-3;
-    options.max_cpu_time = solve_timeout_ms_ / 1000.0;
-    options.verbose = false;
-    options.debug = false;
-    options.print_solver_header = false;
-    options.warm_start = true;
-    options.regularization.initial_value = 1e-3;
-    options.msipddp.segment_length = std::max(1, horizon_steps_ / 4);
-    options.msipddp.rollout_type = "nonlinear";
-
-    auto solver = std::make_unique<cddp::CDDP>(
+    solver_backend_ = std::make_unique<cddp::CDDP>(
         reference_trajectory.states.back(), reference_trajectory.states.back(),
-        horizon_steps_, mpc_dt_, std::move(system), std::move(objective), options);
+        horizon_steps_, mpc_dt_, std::move(system), std::move(objective),
+        buildSolverOptions());
 
     const double min_collective_thrust_n =
         std::max(min_thrust_n_, 4.0 * min_motor_thrust_n_);
@@ -965,14 +1190,26 @@ private:
     Eigen::VectorXd upper_bound(control_dim);
     upper_bound << max_collective_thrust_n, max_roll_torque_nm_, max_pitch_torque_nm_,
         max_yaw_torque_nm_;
-    solver->addPathConstraint(
+    solver_backend_->addPathConstraint(
         "control_bounds",
         std::make_unique<cddp::ControlConstraint>(lower_bound, upper_bound));
-    solver->addPathConstraint(
+    solver_backend_->addPathConstraint(
         "motor_allocation_bounds",
         std::make_unique<cddp_mpc::ThrustAllocationConstraint>(
             arm_length_m_, min_motor_thrust_n_, max_motor_thrust_n_));
-    return solver;
+  }
+
+  void configureSolverBackend(const SolverRequest &request) {
+    initializeSolverBackend(request.reference_trajectory, request.reference_target_enu);
+    solver_backend_->setOptions(buildSolverOptions());
+    solver_system_->setSetpointEnu(request.reference_target_enu);
+    solver_objective_->setReferenceTrajectory(request.reference_trajectory.states,
+                                              request.reference_trajectory.controls);
+    solver_backend_->setInitialState(request.initial_state);
+    solver_backend_->setReferenceState(request.reference_trajectory.states.back());
+    solver_backend_->setReferenceStates(request.reference_trajectory.states);
+    solver_backend_->setInitialTrajectory(request.initial_state_guess,
+                                          request.initial_control_guess);
   }
 
   Eigen::VectorXd
@@ -995,9 +1232,45 @@ private:
     return state;
   }
 
+  double currentYawEnu() const {
+    if (!current_attitude_ned_.has_value()) {
+      return target_yaw_rad_;
+    }
+    return yawFromQuaternionEnu(cddp_mpc::quatNedToEnuWxyz(*current_attitude_ned_));
+  }
+
   ReferenceTrajectory buildReferenceTrajectory(
       const Eigen::VectorXd &initial_state) const {
-    return reference_provider_->build(initial_state);
+    cddp_mpc::PositionYawReferenceProvider provider(buildReferenceConfig());
+    return provider.build(initial_state);
+  }
+
+  Eigen::Vector3d currentMissionTargetEnu() const {
+    if (reference_mode_ == "configured_target") {
+      return Eigen::Vector3d(target_x_m_, target_y_m_, target_z_m_);
+    }
+    if (setpoint_enu_.has_value()) {
+      return *setpoint_enu_;
+    }
+    return Eigen::Vector3d(target_x_m_, target_y_m_, target_z_m_);
+  }
+
+  void updateReferenceManager() {
+    if (!reference_manager_ || !current_position_ned_.has_value() ||
+        !current_attitude_ned_.has_value()) {
+      return;
+    }
+
+    reference_manager_->setConfig(buildReferenceManagerConfig());
+
+    cddp_mpc::MissionReference mission_reference;
+    mission_reference.mode = mode_;
+    mission_reference.target_position_enu = currentMissionTargetEnu();
+    mission_reference.target_yaw_rad = target_yaw_rad_;
+
+    active_reference_status_ = reference_manager_->update(
+        nowSeconds(), cddp_mpc::nedToEnu(*current_position_ned_), currentYawEnu(),
+        mission_reference);
   }
 
   std::vector<Eigen::VectorXd>
@@ -1257,17 +1530,46 @@ private:
     config.hover_thrust_n = hover_thrust_n_;
     config.min_thrust_n = min_thrust_n_;
     config.max_thrust_n = max_thrust_n_;
-    config.max_axis_speed_mps = reference_max_climb_rate_mps_;
-    config.max_axis_accel_mps2 = reference_max_climb_accel_mps2_;
+    config.max_axis_speed_mps =
+        std::max(reference_max_xy_speed_mps_, reference_max_climb_rate_mps_);
+    config.max_axis_accel_mps2 =
+        std::max(reference_max_xy_accel_mps2_, reference_max_climb_accel_mps2_);
     config.max_yaw_rate_rad_s = reference_max_yaw_rate_rad_s_;
     config.smoothing_tau_s = reference_smoothing_tau_s_;
-    config.target_yaw_rad = target_yaw_rad_;
+    config.target_yaw_rad = active_reference_status_.has_value()
+                                ? active_reference_status_->target_yaw_rad
+                                : target_yaw_rad_;
     config.trajectory_period_s = reference_trajectory_period_s_;
     config.circle_radius_m = reference_circle_radius_m_;
     config.figure_eight_amplitude_m = reference_figure_eight_amplitude_m_;
     config.vertical_amplitude_m = reference_vertical_amplitude_m_;
     config.allow_reference_jump = reference_allow_jump_;
-    config.mode = reference_mode_;
+    config.mode =
+        (active_reference_status_.has_value() &&
+         active_reference_status_->source != cddp_mpc::ReferenceSource::Mission)
+            ? "active_setpoint"
+            : reference_mode_;
+    return config;
+  }
+
+  cddp_mpc::ReferenceManagerConfig buildReferenceManagerConfig() const {
+    cddp_mpc::ReferenceManagerConfig config;
+    config.smoothing_tau_s = reference_smoothing_tau_s_;
+    config.max_xy_speed_mps = reference_max_xy_speed_mps_;
+    config.max_z_speed_mps = reference_max_climb_rate_mps_;
+    config.max_xy_accel_mps2 = reference_max_xy_accel_mps2_;
+    config.max_z_accel_mps2 = reference_max_climb_accel_mps2_;
+    config.max_yaw_rate_rad_s = reference_max_yaw_rate_rad_s_;
+    config.teleop_timeout_s = teleop_timeout_s_;
+    config.teleop_max_xy_speed_mps = teleop_max_xy_speed_mps_;
+    config.teleop_max_z_speed_mps = teleop_max_z_speed_mps_;
+    config.teleop_max_yaw_rate_rad_s = teleop_max_yaw_rate_rad_s_;
+    config.teleop_require_deadman = teleop_require_deadman_;
+    config.goal_timeout_s = goal_timeout_s_;
+    config.geofence_half_extent_x_m = geofence_half_extent_x_m_;
+    config.geofence_half_extent_y_m = geofence_half_extent_y_m_;
+    config.geofence_min_z_m = geofence_min_z_m_;
+    config.geofence_max_z_m = geofence_max_z_m_;
     return config;
   }
 
@@ -1284,17 +1586,10 @@ private:
   }
 
   Eigen::Vector3d currentReferenceTargetEnu() const {
-    if (reference_mode_ == "configured_target") {
-      return Eigen::Vector3d(target_x_m_, target_y_m_, target_z_m_);
+    if (active_reference_status_.has_value()) {
+      return active_reference_status_->target_position_enu;
     }
-    if ((mode_ == "TAKEOFF" || mode_ == "HOVER" || mode_ == "LAND") &&
-        setpoint_enu_.has_value()) {
-      return *setpoint_enu_;
-    }
-    if (setpoint_enu_.has_value()) {
-      return *setpoint_enu_;
-    }
-    return Eigen::Vector3d(target_x_m_, target_y_m_, target_z_m_);
+    return currentMissionTargetEnu();
   }
 
   void updateIndiMeasurement(double timestamp_s, const Eigen::Vector3d &body_rates,
@@ -1483,25 +1778,84 @@ private:
         yaw_moment_coefficient_);
   }
 
-  void pollSolveResult() {
-    bool has_overrun_pending = false;
-    auto it = pending_solves_.begin();
-    while (it != pending_solves_.end()) {
-      if (it->future.wait_for(0ms) != std::future_status::ready) {
-        const double age_ms = (nowSeconds() - it->start_time_s) * 1000.0;
-        if (age_ms > solve_timeout_ms_ && !it->timeout_reported) {
-          it->timeout_reported = true;
-          ++solve_timeout_count_;
-          has_overrun_pending = true;
-        } else if (age_ms > solve_timeout_ms_) {
-          ++solve_overrun_count_;
-          has_overrun_pending = true;
+  void queueSolveRequest(SolverRequest request) {
+    std::lock_guard<std::mutex> lock(solver_mutex_);
+    latest_solver_request_ = std::move(request);
+    solver_cv_.notify_one();
+  }
+
+  void stopSolverWorker() {
+    {
+      std::lock_guard<std::mutex> lock(solver_mutex_);
+      stop_solver_worker_ = true;
+      solver_cv_.notify_one();
+    }
+    if (solver_thread_.joinable()) {
+      solver_thread_.join();
+    }
+  }
+
+  void solverWorkerLoop() {
+    while (true) {
+      SolverRequest request;
+      {
+        std::unique_lock<std::mutex> lock(solver_mutex_);
+        solver_cv_.wait(lock, [this]() {
+          return stop_solver_worker_ || latest_solver_request_.has_value();
+        });
+        if (stop_solver_worker_) {
+          return;
         }
-        ++it;
-        continue;
+        request = std::move(*latest_solver_request_);
+        latest_solver_request_.reset();
+        solver_active_request_id_ = request.request_id;
+        solver_active_request_start_time_s_ = nowSeconds();
+        solver_active_timeout_reported_ = false;
+        solver_busy_ = true;
       }
 
-      SolveResult result = it->future.get();
+      CompletedSolve completed;
+      completed.start_time_s = solver_active_request_start_time_s_;
+      completed.reference_target_enu = request.reference_target_enu;
+      completed.result =
+          solveMPC(request.request_id, request.initial_state, request.reference_trajectory,
+                   request.initial_state_guess, request.initial_control_guess,
+                   request.reference_target_enu, request.landing_mode);
+      completed.completion_time_s = nowSeconds();
+      completed.overran_budget =
+          (completed.completion_time_s - completed.start_time_s) * 1000.0 >
+          solve_budget_ms_;
+
+      {
+        std::lock_guard<std::mutex> lock(solver_mutex_);
+        latest_completed_solve_ = std::move(completed);
+        solver_busy_ = false;
+        solver_active_request_id_ = 0;
+      }
+    }
+  }
+
+  void pollSolveResult() {
+    std::optional<CompletedSolve> completed;
+    {
+      std::lock_guard<std::mutex> lock(solver_mutex_);
+      if (latest_completed_solve_.has_value()) {
+        completed = std::move(latest_completed_solve_);
+        latest_completed_solve_.reset();
+      }
+      if (solver_busy_) {
+        const double age_ms = (nowSeconds() - solver_active_request_start_time_s_) * 1000.0;
+        if (age_ms > solve_budget_ms_) {
+          if (!solver_active_timeout_reported_) {
+            solver_active_timeout_reported_ = true;
+            ++solve_timeout_count_;
+          }
+        }
+      }
+    }
+
+    if (completed.has_value()) {
+      const SolveResult &result = completed->result;
       ++solve_count_;
       if (result.request_id > latest_applied_request_id_) {
         latest_applied_request_id_ = result.request_id;
@@ -1513,28 +1867,30 @@ private:
         last_solve_time_ms_ = result.solve_time_ms;
         last_max_constraint_violation_ = result.max_constraint_violation;
         last_raw_bound_violation_ = result.raw_bound_violation;
+        if (completed->overran_budget) {
+          ++solve_overrun_count_;
+          ++consecutive_overrun_cycles_;
+        } else {
+          consecutive_overrun_cycles_ = 0;
+        }
         if (result.success) {
           last_good_command_ = result.command;
-          last_solve_wall_time_s_ = it->start_time_s;
+          last_solve_wall_time_s_ = completed->completion_time_s;
           solve_fail_streak_ = 0;
-          consecutive_overrun_cycles_ = 0;
           last_planned_control_trajectory_ = result.control_trajectory;
+          last_planned_state_trajectory_ = result.state_trajectory;
+          last_planned_reference_target_enu_ = completed->reference_target_enu;
           std::lock_guard<std::mutex> lock(warm_start_mutex_);
           previous_state_guess_ = shiftStateTrajectory(result.state_trajectory);
           previous_control_guess_ = shiftControlTrajectory(result.control_trajectory);
         } else {
           ++solve_fail_streak_;
           last_planned_control_trajectory_.clear();
+          last_planned_state_trajectory_.clear();
           RCLCPP_WARN(get_logger(), "CDDP solve failed: %s",
                       result.status_message.c_str());
         }
       }
-      it = pending_solves_.erase(it);
-    }
-    if (has_overrun_pending) {
-      ++consecutive_overrun_cycles_;
-    } else {
-      consecutive_overrun_cycles_ = 0;
     }
   }
 
@@ -1572,6 +1928,91 @@ private:
     vehicle_torque_pub_->publish(torque_msg);
   }
 
+  void publishReferenceVisualization() {
+    if (!active_reference_status_.has_value()) {
+      return;
+    }
+
+    const auto stamp = get_clock()->now();
+
+    PoseStamped goal_msg{};
+    goal_msg.header.stamp = stamp;
+    goal_msg.header.frame_id = "map";
+    goal_msg.pose.position.x = active_reference_status_->target_position_enu.x();
+    goal_msg.pose.position.y = active_reference_status_->target_position_enu.y();
+    goal_msg.pose.position.z = active_reference_status_->target_position_enu.z();
+    const Eigen::Quaterniond goal_q =
+        cddp_mpc::quaternionFromYaw(active_reference_status_->target_yaw_rad);
+    goal_msg.pose.orientation.w = goal_q.w();
+    goal_msg.pose.orientation.x = goal_q.x();
+    goal_msg.pose.orientation.y = goal_q.y();
+    goal_msg.pose.orientation.z = goal_q.z();
+    active_goal_pub_->publish(goal_msg);
+
+    Path predicted_path{};
+    predicted_path.header = goal_msg.header;
+    predicted_path.poses.reserve(last_planned_state_trajectory_.size());
+    for (const auto &state : last_planned_state_trajectory_) {
+      if (state.size() < 13) {
+        continue;
+      }
+      PoseStamped pose{};
+      pose.header = goal_msg.header;
+      pose.pose.position.x = last_planned_reference_target_enu_.x() + state(0);
+      pose.pose.position.y = last_planned_reference_target_enu_.y() + state(1);
+      pose.pose.position.z = last_planned_reference_target_enu_.z() + state(2);
+      pose.pose.orientation.w = state(3);
+      pose.pose.orientation.x = state(4);
+      pose.pose.orientation.y = state(5);
+      pose.pose.orientation.z = state(6);
+      predicted_path.poses.push_back(std::move(pose));
+    }
+    predicted_path_pub_->publish(predicted_path);
+
+    Marker geofence{};
+    geofence.header = goal_msg.header;
+    geofence.ns = "cddp_mpc";
+    geofence.id = 0;
+    geofence.type = Marker::CUBE;
+    geofence.action = Marker::ADD;
+    geofence.pose.orientation.w = 1.0;
+    geofence.pose.position.z = 0.5 * (geofence_min_z_m_ + geofence_max_z_m_);
+    geofence.scale.x = 2.0 * geofence_half_extent_x_m_;
+    geofence.scale.y = 2.0 * geofence_half_extent_y_m_;
+    geofence.scale.z = std::max(0.05, geofence_max_z_m_ - geofence_min_z_m_);
+    geofence.color.a = 0.12F;
+    geofence.color.r = 0.1F;
+    geofence.color.g = 0.6F;
+    geofence.color.b = 1.0F;
+    geofence_marker_pub_->publish(geofence);
+
+    Marker safety_text{};
+    safety_text.header = goal_msg.header;
+    safety_text.ns = "cddp_mpc";
+    safety_text.id = 1;
+    safety_text.type = Marker::TEXT_VIEW_FACING;
+    safety_text.action = Marker::ADD;
+    safety_text.scale.z = 0.25;
+    safety_text.color.a = 1.0F;
+    safety_text.color.r = 1.0F;
+    safety_text.color.g = 1.0F;
+    safety_text.color.b = 1.0F;
+    if (current_position_ned_.has_value()) {
+      const Eigen::Vector3d position_enu = cddp_mpc::nedToEnu(*current_position_ned_);
+      safety_text.pose.position.x = position_enu.x();
+      safety_text.pose.position.y = position_enu.y();
+      safety_text.pose.position.z = position_enu.z() + 0.8;
+    } else {
+      safety_text.pose.position = goal_msg.pose.position;
+      safety_text.pose.position.z += 0.8;
+    }
+    safety_text.pose.orientation.w = 1.0;
+    safety_text.text = "mode=" + mode_ + " ref=" + active_reference_status_->source_label +
+                       " solve=" + formatDouble(last_solve_time_ms_, 1) +
+                       "ms status=" + last_status_message_;
+    safety_text_pub_->publish(safety_text);
+  }
+
   void publishVehicleCommand(uint16_t command, float param1 = 0.0F,
                              float param2 = 0.0F) {
     VehicleCommand msg{};
@@ -1579,10 +2020,10 @@ private:
     msg.param1 = param1;
     msg.param2 = param2;
     msg.command = command;
-    msg.target_system = 1;
-    msg.target_component = 1;
-    msg.source_system = 1;
-    msg.source_component = 1;
+    msg.target_system = static_cast<uint8_t>(target_system_);
+    msg.target_component = static_cast<uint8_t>(target_component_);
+    msg.source_system = static_cast<uint8_t>(source_system_);
+    msg.source_component = static_cast<uint8_t>(source_component_);
     msg.from_external = true;
     vehicle_command_pub_->publish(msg);
   }
@@ -1735,7 +2176,7 @@ private:
 
   std::vector<KeyValue> buildDiagnosticValues() const {
     std::vector<KeyValue> values;
-    values.reserve(40);
+    values.reserve(56);
     const double current_z_ned =
         current_position_ned_.has_value() ? current_position_ned_->z() : std::numeric_limits<double>::quiet_NaN();
     const double current_vz_ned =
@@ -1839,6 +2280,35 @@ private:
     push("setpoint_enu_x_m", setpoint_enu_.has_value() ? formatDouble((*setpoint_enu_)(0)) : "nan");
     push("setpoint_enu_y_m", setpoint_enu_.has_value() ? formatDouble((*setpoint_enu_)(1)) : "nan");
     push("setpoint_enu_z_m", setpoint_enu_.has_value() ? formatDouble((*setpoint_enu_)(2)) : "nan");
+    push("active_reference_source",
+         active_reference_status_.has_value() ? active_reference_status_->source_label
+                                              : "uninitialized");
+    push("active_target_enu_x_m", formatDouble(currentReferenceTargetEnu().x()));
+    push("active_target_enu_y_m", formatDouble(currentReferenceTargetEnu().y()));
+    push("active_target_enu_z_m", formatDouble(currentReferenceTargetEnu().z()));
+    push("active_target_yaw_rad",
+         formatDouble(active_reference_status_.has_value()
+                          ? active_reference_status_->target_yaw_rad
+                          : target_yaw_rad_));
+    push("teleop_active",
+         active_reference_status_.has_value() && active_reference_status_->teleop_active
+             ? "true"
+             : "false");
+    push("teleop_deadman_pressed",
+         active_reference_status_.has_value() &&
+                 active_reference_status_->teleop_deadman_pressed
+             ? "true"
+             : "false");
+    push("goal_fresh",
+         active_reference_status_.has_value() && active_reference_status_->goal_fresh
+             ? "true"
+             : "false");
+    push("geofence_clamped",
+         active_reference_status_.has_value() &&
+                 active_reference_status_->geofence_clamped
+             ? "true"
+             : "false");
+    push("solve_budget_ms", formatDouble(solve_budget_ms_));
     push("solver_cmd_thrust_n", formatDouble(solver_cmd_thrust));
     push("published_cmd_thrust_n", formatDouble(published_cmd_thrust));
     push("solver_cmd_tau_x_nm", formatDouble(solver_cmd_torque.x()));
@@ -1952,6 +2422,8 @@ private:
   double terminal_tilt_weight_{8.0};
   double reference_max_climb_rate_mps_{1.0};
   double reference_max_climb_accel_mps2_{1.5};
+  double reference_max_xy_speed_mps_{1.0};
+  double reference_max_xy_accel_mps2_{1.5};
   double reference_max_yaw_rate_rad_s_{0.6};
   double reference_smoothing_tau_s_{0.6};
   double reference_trajectory_period_s_{8.0};
@@ -1964,10 +2436,50 @@ private:
   double target_x_m_{0.0};
   double target_y_m_{0.0};
   double target_z_m_{-3.0};
+  std::string fmu_prefix_{"/fmu"};
+  std::string controller_prefix_{"/cddp_mpc"};
+  int target_system_{1};
+  int target_component_{1};
+  int source_system_{1};
+  int source_component_{1};
+  std::string local_position_topic_{"/fmu/out/vehicle_local_position"};
+  std::string odometry_topic_{"/fmu/out/vehicle_odometry"};
+  std::string attitude_topic_{"/fmu/out/vehicle_attitude"};
+  std::string vehicle_status_topic_{"/fmu/out/vehicle_status"};
+  std::string angular_velocity_topic_{"/fmu/out/vehicle_angular_velocity"};
+  std::string offboard_control_mode_topic_{"/fmu/in/offboard_control_mode"};
+  std::string vehicle_thrust_setpoint_topic_{"/fmu/in/vehicle_thrust_setpoint"};
+  std::string vehicle_torque_setpoint_topic_{"/fmu/in/vehicle_torque_setpoint"};
+  std::string vehicle_command_topic_{"/fmu/in/vehicle_command"};
+  std::string status_topic_{"/cddp_mpc/status"};
+  std::string active_goal_topic_{"/cddp_mpc/active_goal"};
+  std::string predicted_path_topic_{"/cddp_mpc/predicted_path"};
+  std::string geofence_topic_{"/cddp_mpc/geofence"};
+  std::string safety_text_topic_{"/cddp_mpc/safety_text"};
+  std::string start_mission_service_name_{"/cddp_mpc/start_mission"};
+  std::string teleop_topic_{"/teleop/cmd_vel"};
+  std::string joy_topic_{"/joy"};
+  std::string teleop_frame_{"body"};
+  double teleop_timeout_s_{0.2};
+  bool teleop_require_deadman_{true};
+  int teleop_deadman_button_index_{4};
+  double teleop_max_xy_speed_mps_{1.0};
+  double teleop_max_z_speed_mps_{0.6};
+  double teleop_max_yaw_rate_rad_s_{0.8};
+  std::string goal_pose_topic_{"/cddp_mpc/goal_pose"};
+  std::string goal_pose_frame_{"map"};
+  double goal_timeout_s_{1.0};
+  double geofence_half_extent_x_m_{5.0};
+  double geofence_half_extent_y_m_{5.0};
+  double geofence_min_z_m_{0.0};
+  double geofence_max_z_m_{5.0};
 
   int max_iterations_{8};
+  bool realtime_mode_{true};
+  int rti_max_iterations_{5};
   double constraint_tolerance_{0.5};
   double solve_timeout_ms_{450.0};
+  double solve_budget_ms_{450.0};
   double takeoff_min_thrust_margin_n_{1.0};
   double min_flight_thrust_ratio_{0.55};
   double hover_min_thrust_ratio_{1.0};
@@ -2002,6 +2514,7 @@ private:
   std::optional<double> landing_start_time_s_;
   std::optional<double> landing_start_setpoint_z_ned_;
   std::optional<double> latest_reference_thrust_n_;
+  std::optional<cddp_mpc::ReferenceStatus> active_reference_status_;
 
   bool mission_start_requested_{true};
   bool armed_{false};
@@ -2039,19 +2552,36 @@ private:
   double last_plan_age_s_{std::numeric_limits<double>::quiet_NaN()};
   bool stale_plan_rejected_this_cycle_{false};
   bool overrun_hover_active_{false};
+  std::vector<Eigen::VectorXd> last_planned_state_trajectory_;
   std::vector<Eigen::VectorXd> last_planned_control_trajectory_;
+  Eigen::Vector3d last_planned_reference_target_enu_{Eigen::Vector3d::Zero()};
 
   std::optional<std::vector<Eigen::VectorXd>> previous_state_guess_;
   std::optional<std::vector<Eigen::VectorXd>> previous_control_guess_;
   mutable std::mutex warm_start_mutex_;
-  std::vector<PendingSolve> pending_solves_;
   std::uint64_t next_solve_request_id_{0};
   std::uint64_t latest_applied_request_id_{0};
+  std::mutex solver_mutex_;
+  std::condition_variable solver_cv_;
+  std::thread solver_thread_;
+  bool stop_solver_worker_{false};
+  bool solver_busy_{false};
+  bool solver_active_timeout_reported_{false};
+  double solver_active_request_start_time_s_{0.0};
+  std::uint64_t solver_active_request_id_{0};
+  std::optional<SolverRequest> latest_solver_request_;
+  std::optional<CompletedSolve> latest_completed_solve_;
+  std::unique_ptr<cddp::CDDP> solver_backend_;
+  cddp_mpc::ErrorStateEnuQuadrotorThrust *solver_system_{nullptr};
+  TrackingQuadraticObjective *solver_objective_{nullptr};
 
   rclcpp::Subscription<VehicleLocalPosition>::SharedPtr local_position_sub_;
   rclcpp::Subscription<VehicleOdometry>::SharedPtr odometry_sub_;
   rclcpp::Subscription<VehicleAttitude>::SharedPtr attitude_sub_;
   rclcpp::Subscription<VehicleStatus>::SharedPtr vehicle_status_sub_;
+  rclcpp::Subscription<TwistStamped>::SharedPtr teleop_sub_;
+  rclcpp::Subscription<Joy>::SharedPtr joy_sub_;
+  rclcpp::Subscription<PoseStamped>::SharedPtr goal_pose_sub_;
 #if CDDP_MPC_HAS_VEHICLE_ANGULAR_VELOCITY
   rclcpp::Subscription<VehicleAngularVelocity>::SharedPtr angular_velocity_sub_;
 #endif
@@ -2061,6 +2591,10 @@ private:
   rclcpp::Publisher<VehicleTorqueSetpoint>::SharedPtr vehicle_torque_pub_;
   rclcpp::Publisher<VehicleCommand>::SharedPtr vehicle_command_pub_;
   rclcpp::Publisher<DiagnosticArray>::SharedPtr diagnostic_pub_;
+  rclcpp::Publisher<PoseStamped>::SharedPtr active_goal_pub_;
+  rclcpp::Publisher<Path>::SharedPtr predicted_path_pub_;
+  rclcpp::Publisher<Marker>::SharedPtr geofence_marker_pub_;
+  rclcpp::Publisher<Marker>::SharedPtr safety_text_pub_;
 
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_mission_service_;
 
@@ -2069,6 +2603,7 @@ private:
   rclcpp::TimerBase::SharedPtr offboard_timer_;
 
   std::unique_ptr<cddp_mpc::ReferenceProvider> reference_provider_;
+  std::unique_ptr<cddp_mpc::ReferenceManager> reference_manager_;
   std::unique_ptr<cddp_mpc::IndiRotationalCompensator> rotational_indi_;
   cddp_mpc::IndiRotationalCompensator::Status default_indi_status_{};
   std::string latest_rate_measurement_source_{"none"};

--- a/src/px4_mpc_node.cpp
+++ b/src/px4_mpc_node.cpp
@@ -803,8 +803,19 @@ private:
     const Eigen::Quaterniond orientation(
         msg->pose.orientation.w, msg->pose.orientation.x, msg->pose.orientation.y,
         msg->pose.orientation.z);
-    const Eigen::Vector3d position(msg->pose.position.x, msg->pose.position.y,
-                                   msg->pose.position.z);
+    Eigen::Vector3d position(msg->pose.position.x, msg->pose.position.y,
+                             msg->pose.position.z);
+    if (std::abs(position.z()) <= 1e-6) {
+      if (active_reference_status_.has_value()) {
+        position.z() = active_reference_status_->target_position_enu.z();
+      } else if (current_position_ned_.has_value()) {
+        position.z() = cddp_mpc::nedToEnu(*current_position_ned_).z();
+      } else if (setpoint_enu_.has_value()) {
+        position.z() = (*setpoint_enu_).z();
+      } else {
+        position.z() = target_z_m_;
+      }
+    }
     reference_manager_->updateGoalPose(nowSeconds(), position,
                                        yawFromQuaternionEnu(orientation));
   }

--- a/src/px4_mpc_node.cpp
+++ b/src/px4_mpc_node.cpp
@@ -1937,7 +1937,7 @@ private:
 
     PoseStamped goal_msg{};
     goal_msg.header.stamp = stamp;
-    goal_msg.header.frame_id = "map";
+    goal_msg.header.frame_id = goal_pose_frame_;
     goal_msg.pose.position.x = active_reference_status_->target_position_enu.x();
     goal_msg.pose.position.y = active_reference_status_->target_position_enu.y();
     goal_msg.pose.position.z = active_reference_status_->target_position_enu.z();

--- a/src/px4_visualizer.cpp
+++ b/src/px4_visualizer.cpp
@@ -1,60 +1,142 @@
 #include <cmath>
-#include <exception>
+#include <functional>
+#include <memory>
 #include <optional>
 #include <string>
 
-#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
+#include <interactive_markers/interactive_marker_server.hpp>
 #include <nav_msgs/msg/path.hpp>
 #include <px4_msgs/msg/vehicle_attitude.hpp>
 #include <px4_msgs/msg/vehicle_local_position.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <visualization_msgs/msg/interactive_marker.hpp>
+#include <visualization_msgs/msg/interactive_marker_control.hpp>
+#include <visualization_msgs/msg/interactive_marker_feedback.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include <Eigen/Dense>
 
 #include "cddp_mpc/px4_utils.hpp"
 
+namespace {
+
+std::string trimTrailingSlashes(std::string value) {
+  while (value.size() > 1 && value.back() == '/') {
+    value.pop_back();
+  }
+  return value;
+}
+
+std::string topicFromPrefix(const std::string &prefix, const std::string &suffix) {
+  const std::string normalized_prefix = trimTrailingSlashes(prefix);
+  if (normalized_prefix.empty()) {
+    return suffix;
+  }
+  if (normalized_prefix == "/") {
+    return "/" + suffix;
+  }
+  return normalized_prefix + "/" + suffix;
+}
+
+} // namespace
+
 class PX4Visualizer : public rclcpp::Node {
 public:
-  PX4Visualizer() : Node("px4_visualizer") {
+  explicit PX4Visualizer(const rclcpp::NodeOptions &options = rclcpp::NodeOptions())
+      : Node("px4_visualizer", options) {
+    loadParameters();
+
     auto px4_qos = rclcpp::QoS(rclcpp::KeepLast(10))
                        .reliability(RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT)
                        .durability(RMW_QOS_POLICY_DURABILITY_VOLATILE);
-    auto diag_qos = rclcpp::QoS(rclcpp::KeepLast(10));
+    auto viz_qos = rclcpp::QoS(rclcpp::KeepLast(10));
 
     attitude_sub_ = create_subscription<px4_msgs::msg::VehicleAttitude>(
-        "/fmu/out/vehicle_attitude", px4_qos,
+        attitude_topic_, px4_qos,
         std::bind(&PX4Visualizer::attitudeCallback, this, std::placeholders::_1));
 
     position_sub_ = create_subscription<px4_msgs::msg::VehicleLocalPosition>(
-        "/fmu/out/vehicle_local_position", px4_qos,
+        local_position_topic_, px4_qos,
         std::bind(&PX4Visualizer::positionCallback, this, std::placeholders::_1));
 
-    diagnostic_sub_ = create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-        "/cddp_mpc/status", diag_qos,
-        std::bind(&PX4Visualizer::diagnosticCallback, this, std::placeholders::_1));
+    active_goal_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+        active_goal_topic_, viz_qos,
+        std::bind(&PX4Visualizer::activeGoalCallback, this, std::placeholders::_1));
 
     vehicle_pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>(
-        "/px4_visualizer/vehicle_pose", 10);
+        vehicle_pose_topic_, 10);
+    goal_pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>(
+        goal_pose_topic_, 10);
     vehicle_path_pub_ = create_publisher<nav_msgs::msg::Path>(
-        "/px4_visualizer/vehicle_path", 10);
+        vehicle_path_topic_, 10);
     setpoint_path_pub_ = create_publisher<nav_msgs::msg::Path>(
-        "/px4_visualizer/setpoint_path", 10);
+        setpoint_path_topic_, 10);
     velocity_marker_pub_ = create_publisher<visualization_msgs::msg::Marker>(
-        "/px4_visualizer/vehicle_velocity", 10);
+        vehicle_velocity_topic_, 10);
     setpoint_marker_pub_ = create_publisher<visualization_msgs::msg::Marker>(
-        "/px4_visualizer/setpoint_marker", 10);
+        setpoint_marker_topic_, 10);
+
+    interactive_marker_server_ =
+        std::make_unique<interactive_markers::InteractiveMarkerServer>(
+            interactive_goal_server_name_, get_node_base_interface(),
+            get_node_clock_interface(), get_node_logging_interface(),
+            get_node_topics_interface(), get_node_services_interface());
+    upsertInteractiveGoalMarker(makeDefaultGoalPose());
 
     timer_ = create_wall_timer(
         std::chrono::milliseconds(50),
         std::bind(&PX4Visualizer::publishVisualization, this));
 
     RCLCPP_INFO(get_logger(),
-                "PX4 visualizer initialized for Foxglove-friendly ROS topics.");
+                "PX4 visualizer initialized for fmu_prefix=%s controller_prefix=%s.",
+                fmu_prefix_.c_str(), controller_prefix_.c_str());
   }
 
 private:
+  static constexpr const char *kInteractiveGoalMarkerName = "goal_reference";
+  static constexpr double kGoalSyncPositionToleranceM = 0.05;
+  static constexpr double kGoalSyncOrientationTolerance = 1e-3;
+  static constexpr double kGoalSyncTimeoutS = 0.5;
+
+  template <typename T>
+  T declareOrGet(const std::string &name, const T &default_value) {
+    if (!has_parameter(name)) {
+      declare_parameter<T>(name, default_value);
+    }
+    return get_parameter(name).template get_value<T>();
+  }
+
+  void loadParameters() {
+    fmu_prefix_ = trimTrailingSlashes(declareOrGet("fmu_prefix", std::string("/fmu")));
+    controller_prefix_ = trimTrailingSlashes(
+        declareOrGet("controller_prefix", std::string("/cddp_mpc")));
+    visualizer_prefix_ = trimTrailingSlashes(
+        declareOrGet("visualizer_prefix", std::string("/px4_visualizer")));
+    map_frame_ = declareOrGet("map_frame", std::string("map"));
+
+    attitude_topic_ = declareOrGet(
+        "attitude_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_attitude"));
+    local_position_topic_ = declareOrGet(
+        "local_position_topic", topicFromPrefix(fmu_prefix_, "out/vehicle_local_position"));
+    active_goal_topic_ = declareOrGet(
+        "active_goal_topic", topicFromPrefix(controller_prefix_, "active_goal"));
+    goal_pose_topic_ = declareOrGet(
+        "goal_pose_topic", topicFromPrefix(controller_prefix_, "goal_pose"));
+    interactive_goal_server_name_ = declareOrGet(
+        "interactive_goal_server", topicFromPrefix(controller_prefix_, "interactive_goal"));
+    vehicle_pose_topic_ = declareOrGet(
+        "vehicle_pose_topic", topicFromPrefix(visualizer_prefix_, "vehicle_pose"));
+    vehicle_path_topic_ = declareOrGet(
+        "vehicle_path_topic", topicFromPrefix(visualizer_prefix_, "vehicle_path"));
+    setpoint_path_topic_ = declareOrGet(
+        "setpoint_path_topic", topicFromPrefix(visualizer_prefix_, "setpoint_path"));
+    vehicle_velocity_topic_ = declareOrGet(
+        "vehicle_velocity_topic", topicFromPrefix(visualizer_prefix_, "vehicle_velocity"));
+    setpoint_marker_topic_ = declareOrGet(
+        "setpoint_marker_topic", topicFromPrefix(visualizer_prefix_, "setpoint_marker"));
+  }
+
   static geometry_msgs::msg::Quaternion
   toGeometryQuaternion(const Eigen::Quaterniond &q) {
     geometry_msgs::msg::Quaternion msg;
@@ -65,15 +147,21 @@ private:
     return msg;
   }
 
-  static std::optional<double> parseDouble(const std::string &text) {
-    try {
-      const double value = std::stod(text);
-      if (std::isfinite(value)) {
-        return value;
-      }
-    } catch (const std::exception &) {
+  static bool posesMatch(const geometry_msgs::msg::Pose &lhs,
+                         const geometry_msgs::msg::Pose &rhs) {
+    const double dx = lhs.position.x - rhs.position.x;
+    const double dy = lhs.position.y - rhs.position.y;
+    const double dz = lhs.position.z - rhs.position.z;
+    const double position_error = std::sqrt(dx * dx + dy * dy + dz * dz);
+    if (position_error > kGoalSyncPositionToleranceM) {
+      return false;
     }
-    return std::nullopt;
+
+    const Eigen::Quaterniond q_lhs(lhs.orientation.w, lhs.orientation.x,
+                                   lhs.orientation.y, lhs.orientation.z);
+    const Eigen::Quaterniond q_rhs(rhs.orientation.w, rhs.orientation.x,
+                                   rhs.orientation.y, rhs.orientation.z);
+    return 1.0 - std::abs(q_lhs.dot(q_rhs)) <= kGoalSyncOrientationTolerance;
   }
 
   void appendPose(nav_msgs::msg::Path &path,
@@ -107,41 +195,145 @@ private:
     position_received_ = true;
   }
 
-  void diagnosticCallback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr msg) {
-    std::optional<double> setpoint_x;
-    std::optional<double> setpoint_y;
-    std::optional<double> setpoint_z;
+  geometry_msgs::msg::PoseStamped makeDefaultGoalPose() const {
+    geometry_msgs::msg::PoseStamped pose;
+    pose.header.stamp = now();
+    pose.header.frame_id = map_frame_;
+    pose.pose.orientation.w = 1.0;
+    return pose;
+  }
 
-    for (const auto &status : msg->status) {
-      if (status.name != "cddp_mpc") {
-        continue;
-      }
-      for (const auto &kv : status.values) {
-        if (kv.key == "setpoint_enu_x_m") {
-          setpoint_x = parseDouble(kv.value);
-        } else if (kv.key == "setpoint_enu_y_m") {
-          setpoint_y = parseDouble(kv.value);
-        } else if (kv.key == "setpoint_enu_z_m") {
-          setpoint_z = parseDouble(kv.value);
-        }
-      }
+  visualization_msgs::msg::Marker makeGoalMarkerBody() const {
+    visualization_msgs::msg::Marker marker;
+    marker.type = visualization_msgs::msg::Marker::ARROW;
+    marker.scale.x = 0.7;
+    marker.scale.y = 0.12;
+    marker.scale.z = 0.12;
+    marker.color.a = 0.85;
+    marker.color.r = 1.0;
+    marker.color.g = 0.55;
+    marker.color.b = 0.0;
+    return marker;
+  }
+
+  static visualization_msgs::msg::InteractiveMarkerControl
+  makeAxisControl(const std::string &name, double x, double y, double z,
+                  uint8_t interaction_mode) {
+    visualization_msgs::msg::InteractiveMarkerControl control;
+    control.name = name;
+    control.orientation.w = 1.0;
+    control.orientation.x = x;
+    control.orientation.y = y;
+    control.orientation.z = z;
+    control.interaction_mode = interaction_mode;
+    return control;
+  }
+
+  visualization_msgs::msg::InteractiveMarker
+  makeInteractiveGoalMarker(const geometry_msgs::msg::PoseStamped &pose) const {
+    visualization_msgs::msg::InteractiveMarker marker;
+    marker.header = pose.header;
+    marker.name = kInteractiveGoalMarkerName;
+    marker.description = "Drag goal";
+    marker.scale = 1.0;
+    marker.pose = pose.pose;
+
+    visualization_msgs::msg::InteractiveMarkerControl visual_control;
+    visual_control.name = "goal_visual";
+    visual_control.always_visible = true;
+    visual_control.interaction_mode =
+        visualization_msgs::msg::InteractiveMarkerControl::NONE;
+    visual_control.markers.push_back(makeGoalMarkerBody());
+    marker.controls.push_back(visual_control);
+
+    marker.controls.push_back(
+        makeAxisControl("move_xy", 0.0, 0.0, 1.0,
+                        visualization_msgs::msg::InteractiveMarkerControl::MOVE_PLANE));
+    marker.controls.push_back(
+        makeAxisControl("move_z", 0.0, 0.0, 1.0,
+                        visualization_msgs::msg::InteractiveMarkerControl::MOVE_AXIS));
+    marker.controls.push_back(
+        makeAxisControl("rotate_z", 0.0, 0.0, 1.0,
+                        visualization_msgs::msg::InteractiveMarkerControl::ROTATE_AXIS));
+
+    return marker;
+  }
+
+  void upsertInteractiveGoalMarker(const geometry_msgs::msg::PoseStamped &pose) {
+    if (!interactive_marker_server_) {
+      return;
     }
 
-    if (!setpoint_x.has_value() || !setpoint_y.has_value() ||
-        !setpoint_z.has_value()) {
+    if (!interactive_marker_initialized_) {
+      interactive_marker_server_->insert(
+          makeInteractiveGoalMarker(pose),
+          std::bind(&PX4Visualizer::interactiveGoalFeedbackCallback, this,
+                    std::placeholders::_1));
+      interactive_marker_initialized_ = true;
+    } else {
+      interactive_marker_server_->setPose(kInteractiveGoalMarkerName, pose.pose,
+                                          pose.header);
+    }
+    interactive_marker_server_->applyChanges();
+  }
+
+  void publishInteractiveGoalPose(const geometry_msgs::msg::PoseStamped &pose) {
+    goal_pose_pub_->publish(pose);
+  }
+
+  void interactiveGoalFeedbackCallback(
+      const visualization_msgs::msg::InteractiveMarkerFeedback::ConstSharedPtr
+          feedback) {
+    if (feedback->marker_name != kInteractiveGoalMarkerName) {
+      return;
+    }
+    if (feedback->event_type ==
+        visualization_msgs::msg::InteractiveMarkerFeedback::MOUSE_DOWN) {
+      interactive_goal_dragging_ = true;
+      return;
+    }
+    if (feedback->event_type !=
+            visualization_msgs::msg::InteractiveMarkerFeedback::POSE_UPDATE &&
+        feedback->event_type !=
+            visualization_msgs::msg::InteractiveMarkerFeedback::MOUSE_UP) {
       return;
     }
 
     geometry_msgs::msg::PoseStamped pose;
+    pose.header = feedback->header;
     pose.header.stamp = now();
-    pose.header.frame_id = "map";
-    pose.pose.position.x = *setpoint_x;
-    pose.pose.position.y = *setpoint_y;
-    pose.pose.position.z = *setpoint_z;
-    pose.pose.orientation.w = 1.0;
+    pose.header.frame_id =
+        pose.header.frame_id.empty() ? map_frame_ : pose.header.frame_id;
+    pose.pose = feedback->pose;
 
-    current_setpoint_pose_ = pose;
-    appendPose(setpoint_path_, pose);
+    pending_goal_pose_ = pose;
+    pending_goal_deadline_ =
+        now() + rclcpp::Duration::from_seconds(kGoalSyncTimeoutS);
+    interactive_goal_dragging_ =
+        feedback->event_type !=
+        visualization_msgs::msg::InteractiveMarkerFeedback::MOUSE_UP;
+    publishInteractiveGoalPose(pose);
+  }
+
+  void activeGoalCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+    current_setpoint_pose_ = *msg;
+    appendPose(setpoint_path_, *msg);
+
+    if (interactive_goal_dragging_) {
+      return;
+    }
+
+    if (pending_goal_pose_.has_value()) {
+      if (posesMatch(msg->pose, pending_goal_pose_->pose)) {
+        pending_goal_pose_.reset();
+      } else if (now() < pending_goal_deadline_) {
+        return;
+      } else {
+        pending_goal_pose_.reset();
+      }
+    }
+
+    upsertInteractiveGoalMarker(*msg);
   }
 
   void publishVisualization() {
@@ -153,7 +345,7 @@ private:
 
     geometry_msgs::msg::PoseStamped pose_msg;
     pose_msg.header.stamp = stamp;
-    pose_msg.header.frame_id = "map";
+    pose_msg.header.frame_id = map_frame_;
     pose_msg.pose.position = current_position_;
     pose_msg.pose.orientation = current_attitude_;
     vehicle_pose_pub_->publish(pose_msg);
@@ -162,12 +354,12 @@ private:
     vehicle_path_pub_->publish(vehicle_path_);
 
     setpoint_path_.header.stamp = stamp;
-    setpoint_path_.header.frame_id = "map";
+    setpoint_path_.header.frame_id = map_frame_;
     setpoint_path_pub_->publish(setpoint_path_);
 
     visualization_msgs::msg::Marker velocity_marker;
     velocity_marker.header.stamp = stamp;
-    velocity_marker.header.frame_id = "map";
+    velocity_marker.header.frame_id = map_frame_;
     velocity_marker.ns = "velocity";
     velocity_marker.id = 0;
     velocity_marker.type = visualization_msgs::msg::Marker::ARROW;
@@ -190,7 +382,7 @@ private:
 
     visualization_msgs::msg::Marker setpoint_marker;
     setpoint_marker.header.stamp = stamp;
-    setpoint_marker.header.frame_id = "map";
+    setpoint_marker.header.frame_id = map_frame_;
     setpoint_marker.ns = "setpoint";
     setpoint_marker.id = 1;
     setpoint_marker.type = visualization_msgs::msg::Marker::SPHERE;
@@ -210,30 +402,52 @@ private:
 
   rclcpp::Subscription<px4_msgs::msg::VehicleAttitude>::SharedPtr attitude_sub_;
   rclcpp::Subscription<px4_msgs::msg::VehicleLocalPosition>::SharedPtr position_sub_;
-  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr
-      diagnostic_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr active_goal_sub_;
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr vehicle_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_pose_pub_;
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr vehicle_path_pub_;
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr setpoint_path_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr velocity_marker_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr setpoint_marker_pub_;
 
+  std::unique_ptr<interactive_markers::InteractiveMarkerServer>
+      interactive_marker_server_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   geometry_msgs::msg::Point current_position_{};
   geometry_msgs::msg::Point current_velocity_{};
   geometry_msgs::msg::Quaternion current_attitude_{};
+  std::string fmu_prefix_{"/fmu"};
+  std::string controller_prefix_{"/cddp_mpc"};
+  std::string visualizer_prefix_{"/px4_visualizer"};
+  std::string map_frame_{"map"};
+  std::string attitude_topic_{"/fmu/out/vehicle_attitude"};
+  std::string local_position_topic_{"/fmu/out/vehicle_local_position"};
+  std::string active_goal_topic_{"/cddp_mpc/active_goal"};
+  std::string goal_pose_topic_{"/cddp_mpc/goal_pose"};
+  std::string interactive_goal_server_name_{"/cddp_mpc/interactive_goal"};
+  std::string vehicle_pose_topic_{"/px4_visualizer/vehicle_pose"};
+  std::string vehicle_path_topic_{"/px4_visualizer/vehicle_path"};
+  std::string setpoint_path_topic_{"/px4_visualizer/setpoint_path"};
+  std::string vehicle_velocity_topic_{"/px4_visualizer/vehicle_velocity"};
+  std::string setpoint_marker_topic_{"/px4_visualizer/setpoint_marker"};
   bool position_received_{false};
   bool attitude_received_{false};
   nav_msgs::msg::Path vehicle_path_{};
   nav_msgs::msg::Path setpoint_path_{};
+  bool interactive_marker_initialized_{false};
+  bool interactive_goal_dragging_{false};
+  rclcpp::Time pending_goal_deadline_{0, 0, RCL_ROS_TIME};
+  std::optional<geometry_msgs::msg::PoseStamped> pending_goal_pose_;
   std::optional<geometry_msgs::msg::PoseStamped> current_setpoint_pose_;
 };
 
 int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<PX4Visualizer>());
+  const auto options =
+      rclcpp::NodeOptions().automatically_declare_parameters_from_overrides(true);
+  rclcpp::spin(std::make_shared<PX4Visualizer>(options));
   rclcpp::shutdown();
   return 0;
 }

--- a/src/reference_manager.cpp
+++ b/src/reference_manager.cpp
@@ -1,0 +1,230 @@
+#include "cddp_mpc/reference_manager.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace cddp_mpc {
+
+namespace {
+
+double wrapAngle(double angle_rad) {
+  constexpr double kPi = 3.14159265358979323846;
+  while (angle_rad > kPi) {
+    angle_rad -= 2.0 * kPi;
+  }
+  while (angle_rad < -kPi) {
+    angle_rad += 2.0 * kPi;
+  }
+  return angle_rad;
+}
+
+double clampAbs(double value, double limit) {
+  return std::clamp(value, -std::abs(limit), std::abs(limit));
+}
+
+const char *sourceLabel(ReferenceSource source) {
+  switch (source) {
+  case ReferenceSource::Mission:
+    return "mission";
+  case ReferenceSource::GoalPose:
+    return "goal_pose";
+  case ReferenceSource::Teleop:
+    return "teleop";
+  }
+  return "unknown";
+}
+
+double advanceAxis(double current_position, double *current_velocity,
+                   double desired_position, double tau_s, double max_speed,
+                   double max_accel, double dt_s) {
+  if (dt_s <= 0.0) {
+    return current_position;
+  }
+
+  const double desired_velocity = clampAbs(
+      (desired_position - current_position) / std::max(tau_s, dt_s), max_speed);
+  const double velocity_error = desired_velocity - *current_velocity;
+  *current_velocity += clampAbs(velocity_error, max_accel * dt_s);
+  *current_velocity = clampAbs(*current_velocity, max_speed);
+
+  const double next_position = current_position + (*current_velocity) * dt_s;
+  const bool crossed_target =
+      (desired_position - current_position) * (desired_position - next_position) <= 0.0;
+  if (crossed_target || std::abs(desired_position - next_position) <= 1e-4) {
+    *current_velocity = 0.0;
+    return desired_position;
+  }
+  return next_position;
+}
+
+} // namespace
+
+ReferenceManager::ReferenceManager(ReferenceManagerConfig config)
+    : config_(std::move(config)) {}
+
+void ReferenceManager::setConfig(const ReferenceManagerConfig &config) {
+  config_ = config;
+}
+
+void ReferenceManager::updateTeleopCommand(double time_s,
+                                           const Eigen::Vector3d &linear_velocity,
+                                           double yaw_rate_rad_s,
+                                           TeleopFrame frame) {
+  TeleopCommand command;
+  command.time_s = time_s;
+  command.linear_velocity.x() = clampAbs(linear_velocity.x(), config_.teleop_max_xy_speed_mps);
+  command.linear_velocity.y() = clampAbs(linear_velocity.y(), config_.teleop_max_xy_speed_mps);
+  command.linear_velocity.z() = clampAbs(linear_velocity.z(), config_.teleop_max_z_speed_mps);
+  command.yaw_rate_rad_s =
+      clampAbs(yaw_rate_rad_s, config_.teleop_max_yaw_rate_rad_s);
+  command.frame = frame;
+  latest_teleop_command_ = command;
+}
+
+void ReferenceManager::updateDeadmanState(double time_s, bool pressed) {
+  static_cast<void>(time_s);
+  deadman_pressed_ = pressed;
+}
+
+void ReferenceManager::updateGoalPose(double time_s,
+                                      const Eigen::Vector3d &position_enu,
+                                      double yaw_rad) {
+  GoalPose goal;
+  goal.time_s = time_s;
+  goal.position_enu = position_enu;
+  goal.yaw_rad = wrapAngle(yaw_rad);
+  latest_goal_pose_ = goal;
+}
+
+ReferenceStatus ReferenceManager::update(double time_s,
+                                         const Eigen::Vector3d &current_position_enu,
+                                         double current_yaw_rad,
+                                         const MissionReference &mission_reference) {
+  const bool teleop_fresh =
+      latest_teleop_command_.has_value() &&
+      (time_s - latest_teleop_command_->time_s) <= std::max(config_.teleop_timeout_s, 0.0);
+  const bool teleop_deadman_ok =
+      !config_.teleop_require_deadman || deadman_pressed_;
+  const bool teleop_active = teleop_fresh && teleop_deadman_ok;
+  const bool goal_fresh = latest_goal_pose_.has_value() &&
+                          (time_s - latest_goal_pose_->time_s) <=
+                              std::max(config_.goal_timeout_s, 0.0);
+
+  const double dt_s = last_update_time_s_.has_value()
+                          ? std::clamp(time_s - *last_update_time_s_, 0.0, 0.5)
+                          : 0.0;
+  last_update_time_s_ = time_s;
+
+  Eigen::Vector3d desired_position_enu = mission_reference.target_position_enu;
+  double desired_yaw_rad = wrapAngle(mission_reference.target_yaw_rad);
+  ReferenceSource source = ReferenceSource::Mission;
+
+  if (teleop_active) {
+    source = ReferenceSource::Teleop;
+    const Eigen::Vector3d reference_origin =
+        initialized_ ? active_target_position_enu_ : current_position_enu;
+    desired_position_enu = reference_origin + teleopVelocityWorld(current_yaw_rad) * dt_s;
+    const double yaw_origin = initialized_ ? active_target_yaw_rad_ : current_yaw_rad;
+    desired_yaw_rad = wrapAngle(
+        yaw_origin + latest_teleop_command_->yaw_rate_rad_s * dt_s);
+  } else if (goal_fresh) {
+    source = ReferenceSource::GoalPose;
+    desired_position_enu = latest_goal_pose_->position_enu;
+    desired_yaw_rad = latest_goal_pose_->yaw_rad;
+  }
+
+  bool geofence_clamped = false;
+  desired_position_enu = clampToGeofence(desired_position_enu, &geofence_clamped);
+
+  if (!initialized_) {
+    initializeTarget(desired_position_enu, desired_yaw_rad);
+  } else {
+    advanceTarget(desired_position_enu, desired_yaw_rad, dt_s);
+  }
+
+  ReferenceStatus status;
+  status.source = source;
+  status.source_label = sourceLabel(source);
+  status.target_position_enu = active_target_position_enu_;
+  status.target_yaw_rad = active_target_yaw_rad_;
+  status.teleop_active = teleop_active;
+  status.teleop_deadman_pressed = deadman_pressed_;
+  status.goal_fresh = goal_fresh;
+  status.geofence_clamped = geofence_clamped;
+  return status;
+}
+
+void ReferenceManager::initializeTarget(const Eigen::Vector3d &position_enu,
+                                        double yaw_rad) {
+  active_target_position_enu_ = position_enu;
+  active_target_velocity_enu_.setZero();
+  active_target_yaw_rad_ = wrapAngle(yaw_rad);
+  initialized_ = true;
+}
+
+Eigen::Vector3d ReferenceManager::clampToGeofence(const Eigen::Vector3d &position_enu,
+                                                  bool *clamped) const {
+  Eigen::Vector3d clamped_position = position_enu;
+  clamped_position.x() = std::clamp(position_enu.x(), -config_.geofence_half_extent_x_m,
+                                    config_.geofence_half_extent_x_m);
+  clamped_position.y() = std::clamp(position_enu.y(), -config_.geofence_half_extent_y_m,
+                                    config_.geofence_half_extent_y_m);
+  clamped_position.z() = std::clamp(position_enu.z(), config_.geofence_min_z_m,
+                                    config_.geofence_max_z_m);
+  if (clamped != nullptr) {
+    *clamped = !clamped_position.isApprox(position_enu, 1e-9);
+  }
+  return clamped_position;
+}
+
+Eigen::Vector3d ReferenceManager::teleopVelocityWorld(double current_yaw_rad) const {
+  if (!latest_teleop_command_.has_value()) {
+    return Eigen::Vector3d::Zero();
+  }
+
+  if (latest_teleop_command_->frame == TeleopFrame::World) {
+    return latest_teleop_command_->linear_velocity;
+  }
+
+  const double cos_yaw = std::cos(current_yaw_rad);
+  const double sin_yaw = std::sin(current_yaw_rad);
+  const Eigen::Vector3d &body_velocity = latest_teleop_command_->linear_velocity;
+
+  Eigen::Vector3d world_velocity = Eigen::Vector3d::Zero();
+  world_velocity.x() = cos_yaw * body_velocity.x() - sin_yaw * body_velocity.y();
+  world_velocity.y() = sin_yaw * body_velocity.x() + cos_yaw * body_velocity.y();
+  world_velocity.z() = body_velocity.z();
+  return world_velocity;
+}
+
+void ReferenceManager::advanceTarget(const Eigen::Vector3d &desired_position_enu,
+                                     double desired_yaw_rad, double dt_s) {
+  const double tau_s = std::max(config_.smoothing_tau_s, 1e-3);
+  const double xy_speed = std::max(config_.max_xy_speed_mps, 0.0);
+  const double z_speed = std::max(config_.max_z_speed_mps, 0.0);
+  const double xy_accel = std::max(config_.max_xy_accel_mps2, 0.0);
+  const double z_accel = std::max(config_.max_z_accel_mps2, 0.0);
+
+  active_target_position_enu_.x() = advanceAxis(
+      active_target_position_enu_.x(), &active_target_velocity_enu_.x(),
+      desired_position_enu.x(), tau_s, xy_speed, xy_accel, dt_s);
+  active_target_position_enu_.y() = advanceAxis(
+      active_target_position_enu_.y(), &active_target_velocity_enu_.y(),
+      desired_position_enu.y(), tau_s, xy_speed, xy_accel, dt_s);
+  active_target_position_enu_.z() = advanceAxis(
+      active_target_position_enu_.z(), &active_target_velocity_enu_.z(),
+      desired_position_enu.z(), tau_s, z_speed, z_accel, dt_s);
+
+  if (dt_s <= 0.0) {
+    active_target_yaw_rad_ = wrapAngle(desired_yaw_rad);
+    return;
+  }
+
+  const double max_yaw_step = std::max(config_.max_yaw_rate_rad_s, 0.0) * dt_s;
+  const double delta = wrapAngle(desired_yaw_rad - active_target_yaw_rad_);
+  active_target_yaw_rad_ = wrapAngle(active_target_yaw_rad_ +
+                                     std::clamp(delta, -max_yaw_step, max_yaw_step));
+}
+
+} // namespace cddp_mpc

--- a/src/reference_manager.cpp
+++ b/src/reference_manager.cpp
@@ -110,6 +110,7 @@ ReferenceStatus ReferenceManager::update(double time_s,
   const bool goal_fresh = latest_goal_pose_.has_value() &&
                           (time_s - latest_goal_pose_->time_s) <=
                               std::max(config_.goal_timeout_s, 0.0);
+  const bool goal_active = latest_goal_pose_.has_value();
 
   const double dt_s = last_update_time_s_.has_value()
                           ? std::clamp(time_s - *last_update_time_s_, 0.0, 0.5)
@@ -128,7 +129,7 @@ ReferenceStatus ReferenceManager::update(double time_s,
     const double yaw_origin = initialized_ ? active_target_yaw_rad_ : current_yaw_rad;
     desired_yaw_rad = wrapAngle(
         yaw_origin + latest_teleop_command_->yaw_rate_rad_s * dt_s);
-  } else if (goal_fresh) {
+  } else if (goal_active) {
     source = ReferenceSource::GoalPose;
     desired_position_enu = latest_goal_pose_->position_enu;
     desired_yaw_rad = latest_goal_pose_->yaw_rad;

--- a/test/test_calibrate_hover_mass.py
+++ b/test/test_calibrate_hover_mass.py
@@ -176,6 +176,18 @@ class CalibrateHoverMassTests(unittest.TestCase):
         self.assertTrue(node.done)
         self.assertIn("not enough steady hover samples", node.failure_reason)
 
+    def test_prefix_configuration_is_applied_to_subscriptions(self) -> None:
+        config = self.module.CalibrationConfig(
+            fmu_prefix="/px4_0/fmu",
+            controller_prefix="/px4_0/cddp_mpc",
+        )
+
+        node = self.module.HoverMassCalibrator(config)
+
+        topics = {record["topic"] for record in node.subscriptions}
+        self.assertIn("/px4_0/fmu/out/vehicle_status", topics)
+        self.assertIn("/px4_0/cddp_mpc/status", topics)
+
     def test_safe_float_handles_bad_values(self) -> None:
         value = self.module.HoverMassCalibrator._safe_float({"x": "bad"}, "x")
         self.assertTrue(math.isnan(value))

--- a/test/test_multi_vehicle_launch_defaults.py
+++ b/test/test_multi_vehicle_launch_defaults.py
@@ -19,6 +19,15 @@ class MultiVehicleLaunchDefaultsTest(unittest.TestCase):
         self.assertIn('"target_system": str(instance + 1)', text)
         self.assertIn('f"/{namespace}/fmu"', text)
         self.assertIn('_write_generated_overlay(namespace, offset * instance_spacing_m)', text)
+    def test_offboard_launch_rewrites_rviz_goal_topic(self) -> None:
+        launch_path = (
+            Path(__file__).resolve().parents[1]
+            / "launch"
+            / "mpc_offboard.launch.py"
+        )
+        text = launch_path.read_text()
+
+        self.assertIn('text = text.replace("/goal_pose", f"{controller_prefix}/goal_pose")', text)
 
     def test_multi_simulation_launch_uses_px4_instance_namespaces(self) -> None:
         launch_path = (

--- a/test/test_multi_vehicle_launch_defaults.py
+++ b/test/test_multi_vehicle_launch_defaults.py
@@ -15,8 +15,10 @@ class MultiVehicleLaunchDefaultsTest(unittest.TestCase):
 
         self.assertIn('DeclareLaunchArgument("vehicle_count", default_value="2")', text)
         self.assertIn('DeclareLaunchArgument("instance_start", default_value="0")', text)
+        self.assertIn('DeclareLaunchArgument("instance_spacing_m", default_value="2.0")', text)
         self.assertIn('"target_system": str(instance + 1)', text)
         self.assertIn('f"/{namespace}/fmu"', text)
+        self.assertIn('_write_generated_overlay(namespace, offset * instance_spacing_m)', text)
 
     def test_multi_simulation_launch_uses_px4_instance_namespaces(self) -> None:
         launch_path = (

--- a/test/test_multi_vehicle_launch_defaults.py
+++ b/test/test_multi_vehicle_launch_defaults.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+class MultiVehicleLaunchDefaultsTest(unittest.TestCase):
+    def test_multi_offboard_launch_exposes_fleet_arguments(self) -> None:
+        launch_path = (
+            Path(__file__).resolve().parents[1]
+            / "launch"
+            / "multi_quadrotor_offboard.launch.py"
+        )
+        text = launch_path.read_text()
+
+        self.assertIn('DeclareLaunchArgument("vehicle_count", default_value="2")', text)
+        self.assertIn('DeclareLaunchArgument("instance_start", default_value="0")', text)
+        self.assertIn('"target_system": str(instance + 1)', text)
+        self.assertIn('f"/{namespace}/fmu"', text)
+
+    def test_multi_simulation_launch_uses_px4_instance_namespaces(self) -> None:
+        launch_path = (
+            Path(__file__).resolve().parents[1]
+            / "launch"
+            / "multi_quadrotor_simulation.launch.py"
+        )
+        text = launch_path.read_text()
+
+        self.assertIn('"PX4_UXRCE_DDS_NS": namespace', text)
+        self.assertIn('cmd=[str(px4_bin), "-i", str(instance)]', text)
+        self.assertIn('DeclareLaunchArgument("vehicle_count", default_value="2")', text)
+
+    def test_fleet_overlays_define_isolated_prefixes(self) -> None:
+        fleet_dir = Path(__file__).resolve().parents[1] / "config" / "fleet"
+        px4_0 = (fleet_dir / "px4_0.yaml").read_text()
+        px4_1 = (fleet_dir / "px4_1.yaml").read_text()
+
+        self.assertIn("fmu_prefix: /px4_0/fmu", px4_0)
+        self.assertIn("controller_prefix: /px4_0/cddp_mpc", px4_0)
+        self.assertIn("target_system: 1", px4_0)
+        self.assertIn("fmu_prefix: /px4_1/fmu", px4_1)
+        self.assertIn("controller_prefix: /px4_1/cddp_mpc", px4_1)
+        self.assertIn("target_system: 2", px4_1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_reference_manager.cpp
+++ b/test/test_reference_manager.cpp
@@ -65,4 +65,24 @@ TEST(ReferenceManagerTest, TeleopOverridesMissionWhenDeadmanPressed) {
   EXPECT_GT(status.target_position_enu.x(), 0.0);
 }
 
+TEST(ReferenceManagerTest, OneShotGoalRemainsActiveAfterFreshnessWindow) {
+  cddp_mpc::ReferenceManagerConfig config;
+  config.goal_timeout_s = 1.0;
+  cddp_mpc::ReferenceManager manager(config);
+
+  manager.updateGoalPose(1.0, Eigen::Vector3d(2.0, 3.0, 4.0), 0.5);
+
+  cddp_mpc::MissionReference mission;
+  mission.target_position_enu = Eigen::Vector3d(-1.0, -1.0, -1.0);
+  manager.update(1.0, Eigen::Vector3d::Zero(), 0.0, mission);
+  const cddp_mpc::ReferenceStatus status =
+      manager.update(3.0, Eigen::Vector3d::Zero(), 0.0, mission);
+
+  EXPECT_EQ(status.source, cddp_mpc::ReferenceSource::GoalPose);
+  EXPECT_FALSE(status.goal_fresh);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.x(), 2.0);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.y(), 3.0);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.z(), 4.0);
+}
+
 } // namespace

--- a/test/test_reference_manager.cpp
+++ b/test/test_reference_manager.cpp
@@ -1,0 +1,68 @@
+#include <gtest/gtest.h>
+
+#include "cddp_mpc/reference_manager.hpp"
+
+namespace {
+
+TEST(ReferenceManagerTest, GoalPoseGetsClampedToGeofence) {
+  cddp_mpc::ReferenceManagerConfig config;
+  config.geofence_half_extent_x_m = 1.0;
+  config.geofence_half_extent_y_m = 2.0;
+  config.geofence_min_z_m = 0.0;
+  config.geofence_max_z_m = 3.0;
+
+  cddp_mpc::ReferenceManager manager(config);
+  manager.updateGoalPose(1.0, Eigen::Vector3d(5.0, -5.0, 10.0), 0.0);
+
+  cddp_mpc::MissionReference mission;
+  const cddp_mpc::ReferenceStatus status =
+      manager.update(1.0, Eigen::Vector3d::Zero(), 0.0, mission);
+
+  EXPECT_EQ(status.source, cddp_mpc::ReferenceSource::GoalPose);
+  EXPECT_TRUE(status.geofence_clamped);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.x(), 1.0);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.y(), -2.0);
+  EXPECT_DOUBLE_EQ(status.target_position_enu.z(), 3.0);
+}
+
+TEST(ReferenceManagerTest, TeleopRequiresDeadmanWhenEnabled) {
+  cddp_mpc::ReferenceManagerConfig config;
+  config.teleop_require_deadman = true;
+  cddp_mpc::ReferenceManager manager(config);
+
+  manager.updateTeleopCommand(1.0, Eigen::Vector3d(1.0, 0.0, 0.0), 0.0,
+                              cddp_mpc::TeleopFrame::World);
+
+  cddp_mpc::MissionReference mission;
+  mission.target_position_enu = Eigen::Vector3d(0.5, 0.0, 0.0);
+  const cddp_mpc::ReferenceStatus status =
+      manager.update(1.0, Eigen::Vector3d::Zero(), 0.0, mission);
+
+  EXPECT_EQ(status.source, cddp_mpc::ReferenceSource::Mission);
+  EXPECT_FALSE(status.teleop_active);
+  EXPECT_FALSE(status.teleop_deadman_pressed);
+}
+
+TEST(ReferenceManagerTest, TeleopOverridesMissionWhenDeadmanPressed) {
+  cddp_mpc::ReferenceManagerConfig config;
+  config.teleop_require_deadman = true;
+  config.max_xy_speed_mps = 10.0;
+  config.max_xy_accel_mps2 = 20.0;
+  cddp_mpc::ReferenceManager manager(config);
+
+  manager.updateDeadmanState(1.0, true);
+  manager.updateTeleopCommand(1.0, Eigen::Vector3d(1.0, 0.0, 0.0), 0.0,
+                              cddp_mpc::TeleopFrame::World);
+
+  cddp_mpc::MissionReference mission;
+  mission.target_position_enu = Eigen::Vector3d::Zero();
+  manager.update(1.0, Eigen::Vector3d::Zero(), 0.0, mission);
+  const cddp_mpc::ReferenceStatus status =
+      manager.update(1.1, Eigen::Vector3d::Zero(), 0.0, mission);
+
+  EXPECT_EQ(status.source, cddp_mpc::ReferenceSource::Teleop);
+  EXPECT_TRUE(status.teleop_active);
+  EXPECT_GT(status.target_position_enu.x(), 0.0);
+}
+
+} // namespace

--- a/test/test_validate_takeoff_hover.py
+++ b/test/test_validate_takeoff_hover.py
@@ -196,6 +196,19 @@ class ValidateTakeoffHoverTests(unittest.TestCase):
 
         self.assertTrue(criteria["diagnostics_ok"])
 
+    def test_prefix_configuration_is_applied_to_subscriptions(self) -> None:
+        config = self.validator_module.ValidationConfig(
+            fmu_prefix="/px4_1/fmu",
+            controller_prefix="/px4_1/cddp_mpc",
+        )
+
+        node = self.validator_module.HoverMissionValidator(config)
+
+        topics = {record["topic"] for record in node.subscriptions}
+        self.assertIn("/px4_1/fmu/out/vehicle_odometry", topics)
+        self.assertIn("/px4_1/fmu/in/offboard_control_mode", topics)
+        self.assertIn("/px4_1/cddp_mpc/status", topics)
+
     def test_landing_requirement_checks_land_done_and_disarm(self) -> None:
         config = self.validator_module.ValidationConfig(
             validation_mode="offboard",


### PR DESCRIPTION
Summary

Add multi-quadrotor support for the PX4 offboard MPC stack by parameterizing per-vehicle topic roots and MAV IDs, and by adding fleet launch wrappers for multi-instance SITL.

Changes

- parameterize `px4_mpc_node` and `px4_visualizer` so PX4 topic roots, controller topic roots, and MAV target/source IDs are no longer hard-coded to a single vehicle
- extend `mpc_offboard.launch.py` and `hardware_validation.launch.py` with per-instance namespace and prefix arguments while keeping the current single-vehicle defaults intact
- add `multi_quadrotor_simulation.launch.py`, `multi_quadrotor_offboard.launch.py`, and example fleet overlays in `config/fleet/` for namespaced multi-vehicle SITL
- update validation and calibration helper scripts plus their tests to follow per-vehicle prefixes
- document the multi-quadrotor SITL flow in the README

Test Plan

- `python3 -m py_compile launch/mpc_offboard.launch.py launch/hardware_validation.launch.py launch/multi_quadrotor_offboard.launch.py launch/multi_quadrotor_simulation.launch.py examples/validate_takeoff_hover.py examples/calibrate_hover_mass.py test/test_validate_takeoff_hover.py test/test_calibrate_hover_mass.py test/test_multi_vehicle_launch_defaults.py`
- `python3 -m unittest discover -s test -p 'test_validate_takeoff_hover.py'`
- `python3 -m unittest discover -s test -p 'test_calibrate_hover_mass.py'`
- `python3 -m unittest discover -s test -p 'test_multi_vehicle_launch_defaults.py'`
- `python3 -m unittest discover -s test -p 'test_sitl_config_defaults.py'`
- `python3 -m unittest discover -s test -p 'test_rviz_config_defaults.py'`
- not run: C++/ROS build in this shell, because `cmake -S . -B build` fails without `ament_cmake` in `CMAKE_PREFIX_PATH`

Related Issues

- none

How to Test

- launch `ros2 launch cddp_mpc multi_quadrotor_simulation.launch.py vehicle_count:=2`
- launch `ros2 launch cddp_mpc multi_quadrotor_offboard.launch.py vehicle_count:=2`
- confirm the controllers bind to `/px4_0/fmu` and `/px4_1/fmu`, and that each controller publishes `VehicleCommand` with its own target system ID

Screenshots/Videos

- none

Additional Notes

- this PR does not modify unrelated local worktree changes outside the multi-quadrotor support files