### PR TITLE
Restore archived ground-robot demo assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_CXX_STANDARD 17) # Enforce C++17 as the minimum standard
 set(CMAKE_CXX_STANDARD_REQUIRED ON)  # Enforce C++17 as the minimum standard
 set(ABSL_PROPAGATE_CXX_STD ON) # Enforce C++17 for absl
 set(CMAKE_BUILD_TYPE "Release") # Set the build type to Release by default
+option(BUILD_LEGACY_GROUND_DEMOS "Build archived pre-PX4 ground-robot demo nodes" OFF)
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
@@ -85,11 +86,88 @@ ament_target_dependencies(px4_visualizer
   visualization_msgs
 )
 
+if(BUILD_LEGACY_GROUND_DEMOS)
+  find_package(tf2 REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
+
+  add_library(unicycle_lib
+    src/unicycle.cpp
+  )
+  target_include_directories(unicycle_lib PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(unicycle_lib rclcpp geometry_msgs)
+
+  add_executable(legacy_mpc_node src/mpc_node.cpp)
+  target_include_directories(legacy_mpc_node PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(legacy_mpc_node
+    rclcpp
+    geometry_msgs
+    nav_msgs
+    Eigen3
+  )
+  target_link_libraries(legacy_mpc_node cddp)
+
+  add_executable(legacy_car_mpc_node src/car_mpc_node.cpp)
+  target_include_directories(legacy_car_mpc_node PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(legacy_car_mpc_node
+    rclcpp
+    geometry_msgs
+    nav_msgs
+    Eigen3
+  )
+  target_link_libraries(legacy_car_mpc_node cddp)
+
+  add_executable(legacy_unicycle_robot_node
+    src/unicycle_robot_node.cpp
+  )
+  target_include_directories(legacy_unicycle_robot_node PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(legacy_unicycle_robot_node unicycle_lib)
+  ament_target_dependencies(legacy_unicycle_robot_node
+    rclcpp
+    geometry_msgs
+    nav_msgs
+    tf2
+    tf2_geometry_msgs
+  )
+
+  add_executable(legacy_teleop_keyboard_node
+    src/teleop_keyboard.cpp
+  )
+  ament_target_dependencies(legacy_teleop_keyboard_node rclcpp geometry_msgs)
+
+  add_executable(legacy_hardcoded_map_node src/hardcoded_map_node.cpp)
+  ament_target_dependencies(legacy_hardcoded_map_node rclcpp nav_msgs geometry_msgs)
+endif()
+
 install(TARGETS
   px4_mpc_node
   px4_visualizer
   DESTINATION lib/${PROJECT_NAME}
 )
+
+if(BUILD_LEGACY_GROUND_DEMOS)
+  install(TARGETS
+    legacy_mpc_node
+    legacy_car_mpc_node
+    legacy_unicycle_robot_node
+    legacy_teleop_keyboard_node
+    legacy_hardcoded_map_node
+    unicycle_lib
+    DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
+
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME})
@@ -103,7 +181,13 @@ install(DIRECTORY rviz
 install(DIRECTORY examples
   DESTINATION share/${PROJECT_NAME})
 
+install(DIRECTORY legacy
+  DESTINATION share/${PROJECT_NAME})
+
 install(DIRECTORY standalone
+  DESTINATION share/${PROJECT_NAME})
+
+install(DIRECTORY video
   DESTINATION share/${PROJECT_NAME})
 
 install(DIRECTORY include/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A ROS 2 PX4 offboard MPC package built on `cddp-cpp`.
 
+The repository also keeps the older unicycle and car MPC demo stack from the merged `#13` state as archived examples under [`legacy/README.md`](legacy/README.md). Those files are opt-in only through `-DBUILD_LEGACY_GROUND_DEMOS=ON` and are not part of the default supported PX4 workflow.
+
+![Archived ground-robot MPC demo](video/cddp_mpc_demo.gif)
+
 ## Description
 
 This package provides a single PX4-oriented controller path:

--- a/include/cddp_mpc/unicycle.hpp
+++ b/include/cddp_mpc/unicycle.hpp
@@ -1,0 +1,48 @@
+#ifndef UNICYCLE_HPP
+#define UNICYCLE_HPP
+
+#include <vector>
+#include <cmath>
+
+/**
+ * @brief A simple unicycle kinematics model.
+ *
+ * The model accepts linear and angular velocity commands
+ * and uses a Runge–Kutta 4 (RK4) integration method to update its state.
+ */
+class Unicycle {
+public:
+  // Default constructor initializes at the origin with zero heading.
+  Unicycle();
+  // Initialize with a given starting pose.
+  Unicycle(double init_x, double init_y, double init_theta);
+  ~Unicycle();
+
+  /// Set the commanded linear (m/s) and angular (rad/s) velocities.
+  void setCommand(double linear_vel, double angular_vel);
+  
+  /// Propagate the state forward by dt seconds.
+  void update(double dt);
+
+  /// Return the current state as a vector: [x, y, theta].
+  std::vector<double> getState() const;
+
+private:
+  // Current state (x, y, heading).
+  double x_;
+  double y_;
+  double theta_;
+
+  // Commanded inputs.
+  double linear_cmd_;
+  double angular_cmd_;
+
+  // Helper: compute derivatives given state and commands.
+  void computeDerivatives(double x, double y, double theta,
+                          double& dx, double& dy, double& dtheta) const;
+
+  // Helper: propagate state using RK4 integration.
+  void integrateRK4(double dt);
+};
+
+#endif  // UNICYCLE_HPP

--- a/launch/simple_robot_bringup.launch.py
+++ b/launch/simple_robot_bringup.launch.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+def generate_launch_description():
+    # Locate the directory where our RViz config is stored
+    cddp_mpc_package_share = get_package_share_directory('cddp_mpc')
+    rviz_config_file = os.path.join(cddp_mpc_package_share, 'rviz', 'simple_launch.rviz')
+
+    # Node for publishing the grid map
+    grid_map_node = Node(
+        package='cddp_mpc',
+        executable='legacy_hardcoded_map_node',
+        name='hardcoded_map_node',
+        output='screen'
+    )
+
+    # Node for RViz2 with our configuration file
+    rviz_node = Node(
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        arguments=['-d', rviz_config_file],
+        output='screen'
+    )
+
+    # Node for the unicycle robot simulation.
+    # Parameters: robot_id, initial x, y, and yaw.
+    unicycle_node = Node(
+        package='cddp_mpc',
+        executable='legacy_unicycle_robot_node',
+        name='unicycle_robot_node',
+        output='screen',
+        parameters=[{
+            'robot_id': 'robot_1',
+            'init_x': 0.0,
+            'init_y': 0.0,
+            'init_yaw': 0.0
+        }]
+    )
+
+    return LaunchDescription([
+        grid_map_node,
+        rviz_node,
+        unicycle_node,
+    ])

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -1,0 +1,40 @@
+# Legacy Ground-Robot Demo
+
+These files preserve the pre-PX4 unicycle and car MPC examples that were still present at the merged `#13` state of this repository.
+
+They are intentionally archived:
+
+- Build them only with `-DBUILD_LEGACY_GROUND_DEMOS=ON`
+- Use the `legacy_*` executables and `simple_robot_bringup.launch.py`
+- Treat them as historical examples, not the primary supported controller path
+
+Build example:
+
+```bash
+colcon build --packages-select cddp_mpc --cmake-args -DBUILD_LEGACY_GROUND_DEMOS=ON
+```
+
+Bring up the map, RViz, and simple unicycle simulator:
+
+```bash
+ros2 launch cddp_mpc simple_robot_bringup.launch.py
+```
+
+Optional manual teleop:
+
+```bash
+ros2 run cddp_mpc legacy_teleop_keyboard_node --ros-args -p robot_id:=robot_1
+```
+
+Archived MPC nodes:
+
+```bash
+ros2 run cddp_mpc legacy_mpc_node
+ros2 run cddp_mpc legacy_car_mpc_node
+```
+
+Important limitation:
+
+- The archived MPC nodes still expect a path on `/robot_1/global_path`
+- The bringup launch does not provide a path planner
+- The GIF and sources are kept for reference and experimentation, not as a maintained end-to-end demo

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,8 @@
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>px4_msgs</depend>
   <depend>visualization_msgs</depend>
   <depend>eigen</depend>

--- a/rviz/simple_launch.rviz
+++ b/rviz/simple_launch.rviz
@@ -1,0 +1,176 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 549
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 0.6000000238418579
+      Axes Length: 1
+      Axes Radius: 0.10000000149011612
+      Class: rviz_default_plugins/Pose
+      Color: 255; 25; 0
+      Enabled: true
+      Head Length: 0.20000000298023224
+      Head Radius: 0.10000000149011612
+      Name: Pose
+      Shaft Length: 0.30000001192092896
+      Shaft Radius: 0.05000000074505806
+      Shape: Arrow
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_1/pose
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_1/local_path
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz_default_plugins/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: true
+      Name: Map
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /occupancy_map
+      Update Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /occupancy_map_updates
+      Use Timestamp: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 6.590987205505371
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 1.585344910621643
+        Y: 3.119513511657715
+        Z: 1.1292192935943604
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 1.5697963237762451
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 4.718552112579346
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002b0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002fb00fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 397
+  Y: 725

--- a/src/car_mpc_node.cpp
+++ b/src/car_mpc_node.cpp
@@ -1,0 +1,378 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <eigen3/Eigen/Dense>
+#include "cddp.hpp"
+#include "dynamics_model/car.hpp"
+
+class CarMPCNode : public rclcpp::Node {
+public:
+    CarMPCNode() : Node("car_mpc_node") {
+        // Declare parameters
+        this->declare_parameter<std::string>("robot_id", "robot_1");
+        this->declare_parameter<double>("timestep_", 0.1);
+        this->declare_parameter<int>("horizon_", 40);
+        this->declare_parameter<double>("processing_frequency_", 10.0);
+        this->declare_parameter<int>("goal_index_", 7);
+        this->declare_parameter<double>("max_compute_time_", 0.1);
+        this->declare_parameter<double>("wheelbase_", 1.6);
+        this->declare_parameter<double>("max_steering_angle_", 0.5);
+        
+        // Control constraints
+        this->declare_parameter<double>("delta_max_", 0.5);
+        this->declare_parameter<double>("delta_min_", -0.5);
+        this->declare_parameter<double>("a_max_", 1.5);
+        this->declare_parameter<double>("a_min_", -1.5);
+        
+        // Cost parameters
+        this->declare_parameter<double>("Q_x_", 1e-1);
+        this->declare_parameter<double>("Q_y_", 1e-1);
+        this->declare_parameter<double>("Q_theta_", 0e-3);
+        this->declare_parameter<double>("Q_v_", 1e-2);
+        this->declare_parameter<double>("R_delta_", 1e-2);
+        this->declare_parameter<double>("R_a_", 1e-2);
+        this->declare_parameter<double>("Qf_x_", 0e-1);
+        this->declare_parameter<double>("Qf_y_", 0e-1);
+        this->declare_parameter<double>("Qf_theta_", 0.0);
+        this->declare_parameter<double>("Qf_v_", 0.0);
+
+        // Get parameters
+        robot_id_ = this->get_parameter("robot_id").as_string();
+        this->get_parameter("timestep_", timestep_);
+        this->get_parameter("horizon_", horizon_);
+        this->get_parameter("processing_frequency_", processing_frequency_);
+        this->get_parameter("goal_index_", goal_index_);
+        this->get_parameter("max_compute_time_", max_compute_time_);
+        this->get_parameter("wheelbase_", wheelbase_);
+        this->get_parameter("max_steering_angle_", max_steering_angle_);
+        this->get_parameter("delta_max_", delta_max_);
+        this->get_parameter("delta_min_", delta_min_);
+        this->get_parameter("a_max_", a_max_);
+        this->get_parameter("a_min_", a_min_);
+        this->get_parameter("Q_x_", Q_x_);
+        this->get_parameter("Q_y_", Q_y_);
+        this->get_parameter("Q_theta_", Q_theta_);
+        this->get_parameter("Q_v_", Q_v_);
+        this->get_parameter("R_delta_", R_delta_);
+        this->get_parameter("R_a_", R_a_);
+        this->get_parameter("Qf_x_", Qf_x_);
+        this->get_parameter("Qf_y_", Qf_y_);
+        this->get_parameter("Qf_theta_", Qf_theta_);
+        this->get_parameter("Qf_v_", Qf_v_);
+
+        RCLCPP_INFO(this->get_logger(), "Car MPC is initialized");
+
+        // Subscribe goal pose
+        goal_subscription_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+            "/goal_pose", 10, std::bind(&CarMPCNode::goalCallback, this, std::placeholders::_1));
+
+        // Subscribe current pose
+        pose_subscription_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+            robot_id_ + "/pose", 10, std::bind(&CarMPCNode::poseCallback, this, std::placeholders::_1));
+
+        // Subscribe path
+        path_subscription_ = create_subscription<nav_msgs::msg::Path>(
+            robot_id_ + "/global_path", 10, std::bind(&CarMPCNode::pathCallback, this, std::placeholders::_1));
+
+        // Publish control command
+        cmd_vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>(robot_id_ + "/cmd_vel", 10);
+        
+        // Publish local path
+        local_path_publisher_ = create_publisher<nav_msgs::msg::Path>(robot_id_ + "/local_path", 10);
+
+        // Control loop
+        control_timer_ = create_wall_timer(
+            std::chrono::milliseconds((int)(1000.0/processing_frequency_)), std::bind(&CarMPCNode::controlLoop, this));
+    }
+
+private:
+    void goalCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg){
+        goal_pose_ = msg->pose;
+        geometry_msgs::msg::Quaternion q = goal_pose_.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        goal_state_.resize(4);
+        goal_state_ << goal_pose_.position.x, goal_pose_.position.y, euler(2), 0.0;
+        RCLCPP_INFO(this->get_logger(), "goal state = [%f, %f, %f, %f]", 
+                    goal_state_(0), goal_state_(1), goal_state_(2), goal_state_(3));
+    }
+
+    void poseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg){
+        initial_pose_ = msg->pose;
+        geometry_msgs::msg::Quaternion q = initial_pose_.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        initial_state_.resize(4);
+        initial_state_ << initial_pose_.position.x, initial_pose_.position.y, euler(2), 0.0;
+        RCLCPP_INFO(this->get_logger(), "initial state = [%f, %f, %f, %f]", 
+                    initial_state_(0), initial_state_(1), initial_state_(2), initial_state_(3));
+    }
+
+    void pathCallback(const nav_msgs::msg::Path::SharedPtr msg){
+        if (msg->poses.size() == 0){
+            return;
+        }
+        // Set initial state to the first pose in the path
+        geometry_msgs::msg::Quaternion q = msg->poses[0].pose.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        initial_state_ << msg->poses[0].pose.position.x, msg->poses[0].pose.position.y, euler(2), 0.0;
+
+        // Set goal state to the last pose in the path
+        int path_size = msg->poses.size();
+        if (path_size < goal_index_){
+            goal_index_ = path_size - 1;
+        }
+        q = msg->poses[goal_index_].pose.orientation;
+        quat = Eigen::Quaterniond(q.w, q.x, q.y, q.z);
+        euler = getEulerFromQuaternion(quat);
+        goal_state_ << msg->poses[goal_index_].pose.position.x, msg->poses[goal_index_].pose.position.y, euler(2), 0.0;
+
+        // Set reference path
+        X_ref_.resize(msg->poses.size());
+        for (int i = 0; i < msg->poses.size(); i++){
+            geometry_msgs::msg::Quaternion q = msg->poses[i].pose.orientation;
+            Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+            Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+            X_ref_[i].resize(4);
+            X_ref_[i] << msg->poses[i].pose.position.x, msg->poses[i].pose.position.y, euler(2), 0.0;
+        }
+    }
+
+    void initializeCDDP() {
+        // Construct the CDDP solver
+        int state_dim   = 4;  // (x, y, theta, v)
+        int control_dim = 2;  // (steering_angle, acceleration)
+
+        std::string integration_type = "euler";
+        auto system = std::make_unique<cddp::Car>(timestep_, wheelbase_, integration_type);
+
+        Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(state_dim, state_dim);
+        Q(0,0) = Q_x_;
+        Q(1,1) = Q_y_;
+        Q(2,2) = Q_theta_;
+        Q(3,3) = Q_v_;
+
+        Eigen::MatrixXd R = Eigen::MatrixXd::Zero(control_dim, control_dim);
+        R(0,0) = R_delta_;
+        R(1,1) = R_a_;
+
+        Eigen::MatrixXd Qf = Eigen::MatrixXd::Zero(state_dim, state_dim);
+        Qf(0,0) = Qf_x_;
+        Qf(1,1) = Qf_y_;
+        Qf(2,2) = Qf_theta_;
+        Qf(3,3) = Qf_v_;
+
+        std::vector<Eigen::VectorXd> empty_reference_states;
+        auto objective = std::make_unique<cddp::QuadraticObjective>(
+            Q, R, Qf,
+            Eigen::VectorXd::Zero(4),
+            empty_reference_states,
+            timestep_
+        );
+
+        cddp_solver_ = std::make_unique<cddp::CDDP>(
+            Eigen::VectorXd::Zero(4),  
+            Eigen::VectorXd::Zero(4),  
+            horizon_,
+            timestep_
+        );
+
+        // Assign system and objective
+        cddp_solver_->setDynamicalSystem(std::move(system));
+        cddp_solver_->setObjective(std::move(objective));
+
+        // Add control constraints 
+        Eigen::VectorXd lower_bound(control_dim);
+        lower_bound << delta_min_, a_min_;
+        Eigen::VectorXd upper_bound(control_dim);
+        upper_bound << delta_max_, a_max_;
+
+        cddp_solver_->addPathConstraint(
+            "ControlConstraint",
+            std::make_unique<cddp::ControlConstraint>(lower_bound, upper_bound)
+        );
+
+        // Add state constraints on velocity
+        Eigen::VectorXd state_lower_bound(state_dim);
+        state_lower_bound << -1e6, -1e6, -M_PI, -2.0;
+        Eigen::VectorXd state_upper_bound(state_dim);
+        state_upper_bound << 1e6, 1e6, M_PI, 2.0;
+        cddp_solver_->addPathConstraint("StateConstraint",
+                                       std::make_unique<cddp::StateConstraint>(state_lower_bound, state_upper_bound));
+
+        // Set some solver options
+        cddp::CDDPOptions options;
+        options.max_iterations = 50;
+        options.tolerance = 1e-4;
+        options.acceptable_tolerance = 1e-3;
+        options.enable_parallel = true;
+        options.num_threads = 10;
+        options.verbose = true;
+        options.debug = true;
+        options.regularization.initial_value = 1e-2;
+        cddp_solver_->setOptions(options);
+
+        // Provide an initial trajectory guess (X, U)
+        std::vector<Eigen::VectorXd> X(horizon_ + 1, Eigen::VectorXd::Zero(state_dim));
+        std::vector<Eigen::VectorXd> U(horizon_,     Eigen::VectorXd::Zero(control_dim));
+        cddp_solver_->setInitialTrajectory(X, U);
+
+        RCLCPP_INFO(this->get_logger(), "CDDP solver has been constructed");
+    }
+
+    void controlLoop(){
+        // If initial and goal states are not set, return
+        if (initial_state_.size() == 0 || goal_state_.size() == 0){
+            return;
+        }
+
+        // Initialize CDDP solver
+        if (cddp_solver_ == nullptr){
+            initializeCDDP();
+        }
+
+        // Solve CDDP MPC
+        auto [u, X] = solveCDDPMPC();
+
+        // Publish control command
+        // Apply control limits for safety
+        u(0) = std::clamp(u(0), delta_min_, delta_max_);
+        u(1) = std::clamp(u(1), a_min_, a_max_);
+        auto twist_msg = geometry_msgs::msg::Twist();
+        twist_msg.linear.x = u(1);  // acceleration (Car control order: [steering, acceleration])
+        twist_msg.angular.z = u(0); // steering angle
+        cmd_vel_publisher_->publish(twist_msg);
+
+        RCLCPP_INFO(this->get_logger(), "Control command = [%f, %f]", u(0), u(1));
+
+        // Publish local path
+        auto path_msg = nav_msgs::msg::Path();
+        path_msg.header.stamp = this->now();
+        path_msg.header.frame_id = "map";
+        for (int i = 0; i < X.size(); i++){
+            geometry_msgs::msg::PoseStamped pose_stamped;
+            pose_stamped.pose.position.x = X[i](0);
+            pose_stamped.pose.position.y = X[i](1);
+            pose_stamped.pose.position.z = 0.0;
+            
+            Eigen::VectorXd euler(3);
+            euler << 0.0, 0.0, X[i](2);
+            Eigen::Quaterniond quat = getQuaternionFromEuler(euler);
+            pose_stamped.pose.orientation.x = quat.x();
+            pose_stamped.pose.orientation.y = quat.y();
+            pose_stamped.pose.orientation.z = quat.z();
+            pose_stamped.pose.orientation.w = quat.w();
+            path_msg.poses.push_back(pose_stamped);
+        }
+        local_path_publisher_->publish(path_msg);
+
+        RCLCPP_INFO(this->get_logger(), "Local path has been published");
+    }
+
+    // CDDP MPC Solver which returns control input and path
+    std::tuple<Eigen::VectorXd, std::vector<Eigen::VectorXd>> solveCDDPMPC(){
+        int state_dim   = 4;  // (x, y, theta, v)
+        int control_dim = 2;  // (steering_angle, acceleration)
+        
+        // Set initial state
+        cddp_solver_->setInitialState(initial_state_);
+
+        // Set goal state
+        cddp_solver_->setReferenceState(goal_state_);
+
+        // Provide an initial trajectory guess (X, U)
+        std::vector<Eigen::VectorXd> X(horizon_ + 1, Eigen::VectorXd::Zero(state_dim));
+        std::vector<Eigen::VectorXd> U(horizon_,     Eigen::VectorXd::Zero(control_dim));
+        X[0] = initial_state_;
+        for (int i = 0; i < horizon_; i++){
+            U[i] = Eigen::VectorXd::Zero(control_dim);
+            X[i+1] = initial_state_;
+        }
+        cddp_solver_->setInitialTrajectory(X, U);
+
+        RCLCPP_INFO(this->get_logger(), "CDDP solver has been constructed");
+
+        // Solve the problem
+        cddp::CDDPSolution solution = cddp_solver_->solve("MSIPDDP");
+
+        // Extract solution
+        const auto& X_sol = solution.state_trajectory; // size: horizon + 1
+        const auto& U_sol = solution.control_trajectory; // size: horizon
+
+        // Extract control
+        Eigen::VectorXd u = U_sol[0];
+    
+        RCLCPP_INFO(this->get_logger(), "Final state = [%f, %f]", X_sol[horizon_](0), X_sol[horizon_](1));
+
+        return std::make_tuple(u, X_sol);   
+    }
+    
+
+    Eigen::VectorXd getEulerFromQuaternion(const Eigen::Quaterniond& quat){
+        Eigen::Vector3d euler = quat.toRotationMatrix().eulerAngles(0, 1, 2);
+        if (euler(2) > M_PI){
+            euler(2) -= 2*M_PI;
+        } else if (euler(2) < -M_PI){
+            euler(2) += 2*M_PI;
+        }
+        return euler;
+    }
+
+    Eigen::Quaterniond getQuaternionFromEuler(const Eigen::Vector3d& euler){
+        Eigen::AngleAxisd rollAngle(Eigen::AngleAxisd(euler(0), Eigen::Vector3d::UnitX()));
+        Eigen::AngleAxisd pitchAngle(Eigen::AngleAxisd(euler(1), Eigen::Vector3d::UnitY()));
+        Eigen::AngleAxisd yawAngle(Eigen::AngleAxisd(euler(2), Eigen::Vector3d::UnitZ()));
+        Eigen::Quaterniond quat = yawAngle * pitchAngle * rollAngle;
+        return quat;
+    }
+    
+    // Member variables
+    std::string robot_id_;
+    double timestep_;
+    int horizon_;
+    double processing_frequency_;
+    int goal_index_;
+    double max_compute_time_;
+    double wheelbase_;
+    double max_steering_angle_;
+    double delta_max_;
+    double delta_min_;
+    double a_max_;
+    double a_min_;
+    double Q_x_;
+    double Q_y_;
+    double Q_theta_;
+    double Q_v_;
+    double R_delta_;
+    double R_a_;
+    double Qf_x_;
+    double Qf_y_;
+    double Qf_theta_;
+    double Qf_v_;
+
+    geometry_msgs::msg::Pose goal_pose_;
+    geometry_msgs::msg::Pose initial_pose_;
+    Eigen::VectorXd goal_state_;
+    Eigen::VectorXd initial_state_;
+    std::vector<Eigen::VectorXd> X_ref_;
+    std::unique_ptr<cddp::CDDP> cddp_solver_;
+    
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_subscription_;
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_subscription_;
+    rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr path_subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_publisher_;
+    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr local_path_publisher_;
+    rclcpp::TimerBase::SharedPtr control_timer_; 
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<CarMPCNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/src/car_mpc_node.cpp
+++ b/src/car_mpc_node.cpp
@@ -123,7 +123,7 @@ private:
 
         // Set goal state to the last pose in the path
         int path_size = msg->poses.size();
-        if (path_size < goal_index_){
+        if (path_size <= goal_index_){
             goal_index_ = path_size - 1;
         }
         q = msg->poses[goal_index_].pose.orientation;

--- a/src/hardcoded_map_node.cpp
+++ b/src/hardcoded_map_node.cpp
@@ -1,0 +1,99 @@
+#include "rclcpp/rclcpp.hpp"
+#include "nav_msgs/msg/occupancy_grid.hpp"
+#include "geometry_msgs/msg/pose.hpp"
+
+using namespace std::chrono_literals;
+
+class GridMapNode : public rclcpp::Node
+{
+public:
+  GridMapNode()
+  : Node("grid_map_node")
+  {
+    // Declare parameters
+    this->declare_parameter("map_length", 6.0);
+    this->declare_parameter("map_width", 3.0);
+    this->declare_parameter("obstacle_size", 0.41);
+    this->declare_parameter("resolution", 0.1);
+
+    // Get parameter values
+    map_length_ = this->get_parameter("map_length").as_double();
+    map_width_ = this->get_parameter("map_width").as_double();
+    obstacle_size_ = this->get_parameter("obstacle_size").as_double();
+    resolution_ = this->get_parameter("resolution").as_double();
+
+    // Create the publisher
+    grid_pub_ = this->create_publisher<nav_msgs::msg::OccupancyGrid>("/occupancy_map", 10);
+
+    // Create a timer that calls publishGridMap() every 33 milliseconds (~30Hz)
+    timer_ = this->create_wall_timer(33ms, std::bind(&GridMapNode::publishGridMap, this));
+  }
+
+private:
+  void publishGridMap()
+  {
+    // Compute the number of cells in the grid
+    int width_cells = static_cast<int>(map_width_ / resolution_);
+    int height_cells = static_cast<int>(map_length_ / resolution_);
+
+    // Prepare the grid message
+    nav_msgs::msg::OccupancyGrid grid_msg;
+    grid_msg.header.stamp = this->get_clock()->now();
+    grid_msg.header.frame_id = "map";
+    grid_msg.info.resolution = resolution_;
+    grid_msg.info.width = width_cells;
+    grid_msg.info.height = height_cells;
+    grid_msg.info.origin.position.x = 0.0;
+    grid_msg.info.origin.position.y = 0.0;
+    grid_msg.info.origin.position.z = 0.0;
+    grid_msg.info.origin.orientation.w = 1.0;
+    
+    // Initialize the grid data with free space (0)
+    grid_msg.data.assign(width_cells * height_cells, 0);
+    
+    // Add obstacles to the grid
+    addObstacle(grid_msg, 0.762, 2.54);
+    addObstacle(grid_msg, 2.794, 3.429);
+    addObstacle(grid_msg, 0.762, 4.318);
+    
+    // Publish the grid map
+    grid_pub_->publish(grid_msg);
+    // RCLCPP_INFO(this->get_logger(), "Published occupancy grid map");
+  }
+
+  void addObstacle(nav_msgs::msg::OccupancyGrid &grid_msg, double x, double y)
+  {
+    int width_cells = grid_msg.info.width;
+    int height_cells = grid_msg.info.height;
+    int obs_cells = static_cast<int>(obstacle_size_ / resolution_);
+    int obs_x = static_cast<int>(x / resolution_);
+    int obs_y = static_cast<int>(y / resolution_);
+    
+    // Mark cells corresponding to the obstacle with a value of 100 (occupied)
+    for (int i = -obs_cells / 2; i <= obs_cells / 2; ++i)
+    {
+      for (int j = -obs_cells / 2; j <= obs_cells / 2; ++j)
+      {
+        int idx_x = obs_x + i;
+        int idx_y = obs_y + j;
+        if (idx_x >= 0 && idx_x < width_cells && idx_y >= 0 && idx_y < height_cells)
+        {
+          grid_msg.data[idx_y * width_cells + idx_x] = 100;
+        }
+      }
+    }
+  }
+
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr grid_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  double map_length_, map_width_, obstacle_size_, resolution_;
+};
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GridMapNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/mpc_node.cpp
+++ b/src/mpc_node.cpp
@@ -1,0 +1,365 @@
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/pose_array.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+#include <nav_msgs/msg/path.hpp>
+#include <eigen3/Eigen/Dense>
+#include "cddp.hpp"
+
+class MPCNode : public rclcpp::Node {
+public:
+    MPCNode() : Node("mpc_node") {
+        // Declare parameters
+        this->declare_parameter<std::string>("robot_id", "robot_1");
+        this->declare_parameter<double>("timestep_", 0.1); // NOTE: This is a hyper-parameter and needs to be tuned
+        this->declare_parameter<int>("horizon_", 40); // NOTE: This is a hyper-parameter and needs to be tuned
+        this->declare_parameter<double>("processing_frequency_", 10.0); 
+        this->declare_parameter<int>("goal_index_", 7); // Taking 7th element in the path as goal pose; NOTE: This is a hyper-parameter and needs to be tuned
+        this->declare_parameter<double>("max_compute_time_", 0.1); // Maximum time allowed for computation
+        this->declare_parameter<double>("v_max_", 1.0); // Maximum linear velocity
+        this->declare_parameter<double>("omega_max_", 2*M_PI); // Maximum angular velocity
+        this->declare_parameter<double>("v_min_", -1.0); // Minimum linear velocity
+        this->declare_parameter<double>("omega_min_", -2*M_PI); // Minimum angular velocity
+        this->declare_parameter<double>("Q_x_", 1e-1); // x position cost
+        this->declare_parameter<double>("Q_y_", 1e-1); // y position cost
+        this->declare_parameter<double>("Q_theta_", 0e-3); // yaw angle cost
+        this->declare_parameter<double>("R_v_", 1e-2); // linear velocity cost
+        this->declare_parameter<double>("R_omega_", 1e-2); // angular velocity cost
+        this->declare_parameter<double>("Qf_x_", 0e-1); // x position cost at final state
+        this->declare_parameter<double>("Qf_y_", 0e-1); // y position cost at final state
+        this->declare_parameter<double>("Qf_theta_", 0.0); // yaw angle cost at final state
+
+        // Get parameters
+        robot_id_ = this->get_parameter("robot_id").as_string();
+        this->get_parameter("timestep_", timestep_);
+        this->get_parameter("horizon_", horizon_);
+        this->get_parameter("processing_frequency_", processing_frequency_);
+        this->get_parameter("goal_index_", goal_index_);
+        this->get_parameter("max_compute_time_", max_compute_time_);
+        this->get_parameter("v_max_", v_max_);
+        this->get_parameter("omega_max_", omega_max_);
+        this->get_parameter("v_min_", v_min_);
+        this->get_parameter("omega_min_", omega_min_);
+        this->get_parameter("Q_x_", Q_x_);
+        this->get_parameter("Q_y_", Q_y_);
+        this->get_parameter("Q_theta_", Q_theta_);
+        this->get_parameter("R_v_", R_v_);
+        this->get_parameter("R_omega_", R_omega_);
+        this->get_parameter("Qf_x_", Qf_x_);
+        this->get_parameter("Qf_y_", Qf_y_);
+        this->get_parameter("Qf_theta_", Qf_theta_);
+
+        RCLCPP_INFO(this->get_logger(), "MPC is initialized");
+
+        // Subscribe goal pose
+        goal_subscription_ =  create_subscription<geometry_msgs::msg::PoseStamped>(
+            "/goal_pose", 10, std::bind(&MPCNode::goalCallback, this, std::placeholders::_1));
+
+        // Subscribe current pose
+        pose_subscription_ = create_subscription<geometry_msgs::msg::PoseStamped>(
+            robot_id_ + "/pose", 10, std::bind(&MPCNode::poseCallback, this, std::placeholders::_1));
+
+        // Subscribe path
+        path_subscription_ = create_subscription<nav_msgs::msg::Path>(
+            robot_id_ + "/global_path", 10, std::bind(&MPCNode::pathCallback, this, std::placeholders::_1));
+
+        // Publish control command
+        cmd_vel_publisher_ = create_publisher<geometry_msgs::msg::Twist>(robot_id_ + "/cmd_vel", 10);
+        
+
+        // Publish local path
+        local_path_publisher_ = create_publisher<nav_msgs::msg::Path>(robot_id_ + "/local_path", 10);
+
+        // Control loop
+        control_timer_ = create_wall_timer(
+            std::chrono::milliseconds((int)(1000.0/processing_frequency_)), std::bind(&MPCNode::controlLoop, this));
+    }
+
+private:
+    void goalCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg){
+        goal_pose_ = msg->pose;
+        geometry_msgs::msg::Quaternion q = goal_pose_.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        goal_state_.resize(3);
+        goal_state_ << goal_pose_.position.x, goal_pose_.position.y, euler(2);
+        RCLCPP_INFO(this->get_logger(), "goal state = [%f, %f, %f]", goal_state_(0), goal_state_(1), goal_state_(2));
+    }
+
+    void poseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg){
+        initial_pose_ = msg->pose;
+        geometry_msgs::msg::Quaternion q = initial_pose_.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        initial_state_.resize(3);
+        initial_state_ << initial_pose_.position.x, initial_pose_.position.y, euler(2);
+        RCLCPP_INFO(this->get_logger(), "initial state = [%f, %f, %f]", initial_state_(0), initial_state_(1), initial_state_(2));
+    }
+
+    void pathCallback(const nav_msgs::msg::Path::SharedPtr msg){
+        if (msg->poses.size() == 0){
+            return;
+        }
+        // Set initial state to the first pose in the path
+        geometry_msgs::msg::Quaternion q = msg->poses[0].pose.orientation;
+        Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+        Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+        initial_state_ << msg->poses[0].pose.position.x, msg->poses[0].pose.position.y, euler(2);
+
+        // Set goal state to the last pose in the path
+        int path_size = msg->poses.size();
+        if (path_size < goal_index_){
+            goal_index_ = path_size - 1;
+        }
+        q = msg->poses[goal_index_].pose.orientation;
+        quat = Eigen::Quaterniond(q.w, q.x, q.y, q.z);
+        euler = getEulerFromQuaternion(quat);
+        goal_state_ << msg->poses[goal_index_].pose.position.x, msg->poses[goal_index_].pose.position.y, euler(2);
+
+        // Set reference path
+        X_ref_.resize(msg->poses.size());
+        for (int i = 0; i < msg->poses.size(); i++){
+            geometry_msgs::msg::Quaternion q = msg->poses[i].pose.orientation;
+            Eigen::Quaterniond quat(q.w, q.x, q.y, q.z);
+            Eigen::Vector3d euler = getEulerFromQuaternion(quat);
+            X_ref_[i].resize(3);
+            X_ref_[i] << msg->poses[i].pose.position.x, msg->poses[i].pose.position.y, euler(2);
+        }
+    }
+
+    void initializeCDDP() {
+        // ------------------------
+        //  Construct the CDDP solver
+        // ------------------------
+        int state_dim   = 3;  // (x, y, theta)
+        int control_dim = 2;  // (v, omega)
+
+        std::string integration_type = "euler";
+        auto system = std::make_unique<cddp::Unicycle>(timestep_, integration_type);
+
+        Eigen::MatrixXd Q = Eigen::MatrixXd::Zero(state_dim, state_dim);
+        Q(0,0)      = Q_x_;
+        Q(1,1)      = Q_y_;
+        Q(2,2)      = Q_theta_;
+
+        Eigen::MatrixXd R = Eigen::MatrixXd::Zero(control_dim, control_dim);
+        R(0,0)      = R_v_;
+        R(1,1)      = R_omega_;
+
+        Eigen::MatrixXd Qf = Eigen::MatrixXd::Zero(state_dim, state_dim);
+        Qf(0,0)     = Qf_x_;
+        Qf(1,1)     = Qf_y_;
+        Qf(2,2)     = Qf_theta_;
+
+        std::vector<Eigen::VectorXd> empty_reference_states;
+        auto objective = std::make_unique<cddp::QuadraticObjective>(
+            Q, R, Qf,
+            Eigen::VectorXd::Zero(3),
+            empty_reference_states,
+            timestep_
+        );
+
+        cddp_solver_ = std::make_unique<cddp::CDDP>(
+            Eigen::VectorXd::Zero(3),  
+            Eigen::VectorXd::Zero(3),  
+            horizon_,
+            timestep_
+        );
+
+        // Assign system and objective
+        cddp_solver_->setDynamicalSystem(std::move(system));
+        cddp_solver_->setObjective(std::move(objective));
+
+        // Add constraints 
+        Eigen::VectorXd lower_bound(control_dim);
+        lower_bound << v_min_, omega_min_;
+        Eigen::VectorXd upper_bound(control_dim);
+        upper_bound << v_max_, omega_max_;
+
+        cddp_solver_->addPathConstraint(
+            "ControlConstraint",
+            std::make_unique<cddp::ControlConstraint>(lower_bound, upper_bound)
+        );
+
+        // Set some solver options
+        cddp::CDDPOptions options;
+        options.max_iterations = 50;
+        options.tolerance = 1e-4;
+        options.acceptable_tolerance = 1e-3;
+        options.enable_parallel = false;
+        options.num_threads = 1;
+        options.verbose = true;
+        options.debug = true;
+        options.regularization.initial_value = 1e-2;
+        cddp_solver_->setOptions(options);
+
+        // Provide an initial trajectory guess (X, U)
+        std::vector<Eigen::VectorXd> X(horizon_ + 1, Eigen::VectorXd::Zero(state_dim));
+        std::vector<Eigen::VectorXd> U(horizon_,     Eigen::VectorXd::Zero(control_dim));
+        cddp_solver_->setInitialTrajectory(X, U);
+
+        RCLCPP_INFO(this->get_logger(), "CDDP solver has been constructed");
+    }
+
+    void controlLoop(){
+        // If initial and goal states are not set, return
+        if (initial_state_.size() == 0 || goal_state_.size() == 0){
+            return;
+        }
+
+        // Initialize CDDP solver
+        if (cddp_solver_ == nullptr){
+            initializeCDDP();
+        }
+
+        // Solve CDDP MPC
+        auto [u, X] = solveCDDPMPC();
+
+        // Publish control command
+        // Apply control limits for safety
+        u(0) = std::clamp(u(0), v_min_, v_max_);
+        u(1) = std::clamp(u(1), omega_min_, omega_max_);
+        auto twist_msg = geometry_msgs::msg::Twist();
+        twist_msg.linear.x = u(0);
+        twist_msg.angular.z = u(1);
+        cmd_vel_publisher_->publish(twist_msg);
+
+        RCLCPP_INFO(this->get_logger(), "Control command = [%f, %f]", u(0), u(1));
+
+        // Publish local path
+        auto path_msg = nav_msgs::msg::Path();
+        path_msg.header.stamp = this->now();
+        path_msg.header.frame_id = "map";
+        for (int i = 0; i < X.size(); i++){
+            geometry_msgs::msg::PoseStamped pose_stamped;
+            pose_stamped.pose.position.x = X[i](0);
+            pose_stamped.pose.position.y = X[i](1);
+            pose_stamped.pose.position.z = 0.0;
+            
+            Eigen::VectorXd euler(3);
+            euler << 0.0, 0.0, X[i](2);
+            Eigen::Quaterniond quat = getQuaternionFromEuler(euler);
+            pose_stamped.pose.orientation.x = quat.x();
+            pose_stamped.pose.orientation.y = quat.y();
+            pose_stamped.pose.orientation.z = quat.z();
+            pose_stamped.pose.orientation.w = quat.w();
+            path_msg.poses.push_back(pose_stamped);
+        }
+        local_path_publisher_->publish(path_msg);
+
+        RCLCPP_INFO(this->get_logger(), "Local path has been published");
+    }
+
+    // CDDP MPC Solver which returns control input and path
+    std::tuple<Eigen::VectorXd, std::vector<Eigen::VectorXd>> solveCDDPMPC(){
+        int state_dim   = 3;  // (x, y, theta)
+        int control_dim = 2;  // (v, omega)
+        // Set initial state
+        cddp_solver_->setInitialState(initial_state_);
+
+        // Set goal state
+        cddp_solver_->setReferenceState(goal_state_);
+
+        // Provide an initial trajectory guess (X, U)
+        std::vector<Eigen::VectorXd> X(horizon_ + 1, Eigen::VectorXd::Zero(state_dim));
+        std::vector<Eigen::VectorXd> U(horizon_,     Eigen::VectorXd::Zero(control_dim));
+        X[0] = initial_state_;
+        for (int i = 0; i < horizon_; i++){
+            U[i] = Eigen::VectorXd::Zero(control_dim);
+            X[i+1] = initial_state_;
+        }
+        cddp_solver_->setInitialTrajectory(X, U);
+
+        RCLCPP_INFO(this->get_logger(), "CDDP solver has been constructed");
+
+        // Solve the problem
+        cddp::CDDPSolution solution = cddp_solver_->solve("MSIPDDP");
+
+        // Extract solution
+        const auto& X_sol = solution.state_trajectory; // size: horizon + 1
+        const auto& U_sol = solution.control_trajectory; // size: horizon
+
+        // Extract control
+        Eigen::VectorXd u = U_sol[0];
+    
+        RCLCPP_INFO(this->get_logger(), "Final state = [%f, %f]", X_sol[horizon_](0), X_sol[horizon_](1)); // DEBUG INFO
+
+        return std::make_tuple(u, X_sol);   
+    }
+    
+
+    Eigen::VectorXd getEulerFromQuaternion(const Eigen::Quaterniond& quat){
+        Eigen::Vector3d euler = quat.toRotationMatrix().eulerAngles(0, 1, 2);
+        // Wrap yaw between -pi and pi (ONLY INTERESTED IN YAW ANGLE)
+        if (euler(2) > M_PI){
+            euler(2) -= 2*M_PI;
+        } else if (euler(2) < -M_PI){
+            euler(2) += 2*M_PI;
+        }
+        return euler;
+    }
+
+    Eigen::Quaterniond getQuaternionFromEuler(const Eigen::Vector3d& euler){
+        Eigen::AngleAxisd rollAngle(Eigen::AngleAxisd(euler(0), Eigen::Vector3d::UnitX()));
+        Eigen::AngleAxisd pitchAngle(Eigen::AngleAxisd(euler(1), Eigen::Vector3d::UnitY()));
+        Eigen::AngleAxisd yawAngle(Eigen::AngleAxisd(euler(2), Eigen::Vector3d::UnitZ()));
+        Eigen::Quaterniond quat = yawAngle * pitchAngle * rollAngle;
+        return quat;
+    }
+    
+    // Member variables
+    std::string robot_id_;
+    double timestep_;
+    int horizon_;
+    double processing_frequency_;
+    int goal_index_;
+    double max_compute_time_;
+    double v_max_;
+    double omega_max_;
+    double v_min_;
+    double omega_min_;
+    double Q_x_;
+    double Q_y_;
+    double Q_theta_;
+    double R_v_;
+    double R_omega_;
+    double Qf_x_;
+    double Qf_y_;
+    double Qf_theta_;
+
+    geometry_msgs::msg::Pose goal_pose_;
+    geometry_msgs::msg::Pose initial_pose_;
+    Eigen::VectorXd goal_state_;
+    Eigen::VectorXd initial_state_;
+    std::vector<Eigen::VectorXd> X_ref_;
+    std::unique_ptr<cddp::CDDP> cddp_solver_;
+    
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_subscription_;
+    rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_subscription_;
+    rclcpp::Subscription<nav_msgs::msg::Path>::SharedPtr path_subscription_;
+    rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_publisher_;
+    rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr local_path_publisher_;
+    rclcpp::TimerBase::SharedPtr control_timer_; 
+};
+
+int main(int argc, char **argv) {
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<MPCNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}
+
+// TEST COMMANDS
+/*
+// In one terminal, run the following command
+ros2 run cddp_mpc mpc_node
+
+// In another terminal, publish goal pose
+ros2 topic pub /pose geometry_msgs/msg/PoseStamped '{header: {stamp: {sec: 0, nanosec: 0}, frame_id: "map"}, pose: {position: {x: 0.0, y: 0.0, z: 0.0}, orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}}}' 
+
+// In another terminal, publish goal pose
+ros2 topic pub /goal_pose geometry_msgs/msg/PoseStamped '{header: {stamp: {sec: 0, nanosec: 0}, frame_id: "map"}, pose: {position: {x: 2.0, y: 2.0, z: 0.0}, orientation: {x: 0.0, y: 0.0, z: 0.02030303113745028, w: 0.9997938722189849}}}' 
+
+*/

--- a/src/mpc_node.cpp
+++ b/src/mpc_node.cpp
@@ -109,7 +109,7 @@ private:
 
         // Set goal state to the last pose in the path
         int path_size = msg->poses.size();
-        if (path_size < goal_index_){
+        if (path_size <= goal_index_){
             goal_index_ = path_size - 1;
         }
         q = msg->poses[goal_index_].pose.orientation;

--- a/src/teleop_keyboard.cpp
+++ b/src/teleop_keyboard.cpp
@@ -1,0 +1,113 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <iostream>
+#include <termios.h>
+#include <unistd.h>
+
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+using namespace std::chrono_literals;
+
+class TeleopKeyboard : public rclcpp::Node {
+public:
+  TeleopKeyboard()
+  : Node("teleop_keyboard")
+  {
+    // Declare and retrieve the robot_id parameter (default "robot_1")
+    this->declare_parameter<std::string>("robot_id", "robot_1");
+    robot_id_ = this->get_parameter("robot_id").as_string();
+
+    // Construct the cmd_vel topic based on robot_id.
+    std::string cmd_vel_topic = robot_id_ + "/cmd_vel";
+    publisher_ = this->create_publisher<geometry_msgs::msg::Twist>(cmd_vel_topic, 10);
+
+    // Start the keyboard reading thread.
+    keyboard_thread_ = std::thread(std::bind(&TeleopKeyboard::keyboardLoop, this));
+  }
+  
+  ~TeleopKeyboard() {
+    exit_requested_ = true;
+    if (keyboard_thread_.joinable()) {
+      keyboard_thread_.join();
+    }
+  }
+  
+private:
+  void keyboardLoop() {
+    char c;
+    double linear_vel = 0.0;
+    double angular_vel = 0.0;
+    const double linear_step = 0.1;
+    const double angular_step = 0.1;
+    
+    // Set terminal to raw mode for immediate key press reading.
+    struct termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+    
+    std::cout << "\nTeleop Keyboard Control for robot: " << robot_id_ << "\n";
+    std::cout << "-----------------------------------------\n";
+    std::cout << "w: increase forward speed\n";
+    std::cout << "s: decrease forward speed (or move backwards)\n";
+    std::cout << "a: turn left\n";
+    std::cout << "d: turn right\n";
+    std::cout << "x: stop\n";
+    std::cout << "q: quit\n";
+    
+    while (rclcpp::ok() && !exit_requested_) {
+      if (read(STDIN_FILENO, &c, 1) > 0) {
+        geometry_msgs::msg::Twist twist_msg;
+        switch (c) {
+          case 'w':
+            linear_vel += linear_step;
+            break;
+          case 's':
+            linear_vel -= linear_step;
+            break;
+          case 'a':
+            angular_vel += angular_step;
+            break;
+          case 'd':
+            angular_vel -= angular_step;
+            break;
+          case 'x':
+            linear_vel = 0.0;
+            angular_vel = 0.0;
+            break;
+          case 'q':
+            exit_requested_ = true;
+            break;
+          default:
+            break;
+        }
+        twist_msg.linear.x = linear_vel;
+        twist_msg.angular.z = angular_vel;
+        publisher_->publish(twist_msg);
+        std::cout << "Published to " << robot_id_ << "/cmd_vel: linear = " 
+                  << twist_msg.linear.x << ", angular = " << twist_msg.angular.z << "\n";
+      }
+    }
+    // Restore terminal settings before exit.
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+  }
+  
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
+  std::thread keyboard_thread_;
+  bool exit_requested_{false};
+  std::string robot_id_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<TeleopKeyboard>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/unicycle.cpp
+++ b/src/unicycle.cpp
@@ -1,0 +1,66 @@
+#include "cddp_mpc/unicycle.hpp"
+
+Unicycle::Unicycle() 
+  : x_(0.0), y_(0.0), theta_(0.0), linear_cmd_(0.0), angular_cmd_(0.0) {}
+
+Unicycle::Unicycle(double init_x, double init_y, double init_theta)
+  : x_(init_x), y_(init_y), theta_(init_theta), linear_cmd_(0.0), angular_cmd_(0.0) {}
+
+Unicycle::~Unicycle() {}
+
+void Unicycle::setCommand(double linear_vel, double angular_vel) {
+  linear_cmd_ = linear_vel;
+  angular_cmd_ = angular_vel;
+}
+
+std::vector<double> Unicycle::getState() const {
+  return {x_, y_, theta_};
+}
+
+void Unicycle::computeDerivatives(double x, double y, double theta,
+                                  double& dx, double& dy, double& dtheta) const {
+  // Unicycle kinematics:
+  // dx/dt = v * cos(theta)
+  // dy/dt = v * sin(theta)
+  // dtheta/dt = omega
+  dx = linear_cmd_ * std::cos(theta);
+  dy = linear_cmd_ * std::sin(theta);
+  dtheta = angular_cmd_;
+}
+
+void Unicycle::integrateRK4(double dt) {
+  double k1_x, k1_y, k1_theta;
+  double k2_x, k2_y, k2_theta;
+  double k3_x, k3_y, k3_theta;
+  double k4_x, k4_y, k4_theta;
+
+  // k1: initial derivatives.
+  computeDerivatives(x_, y_, theta_, k1_x, k1_y, k1_theta);
+
+  // k2: derivatives at midpoint using k1.
+  double x_mid = x_ + 0.5 * dt * k1_x;
+  double y_mid = y_ + 0.5 * dt * k1_y;
+  double theta_mid = theta_ + 0.5 * dt * k1_theta;
+  computeDerivatives(x_mid, y_mid, theta_mid, k2_x, k2_y, k2_theta);
+
+  // k3: derivatives at midpoint using k2.
+  x_mid = x_ + 0.5 * dt * k2_x;
+  y_mid = y_ + 0.5 * dt * k2_y;
+  theta_mid = theta_ + 0.5 * dt * k2_theta;
+  computeDerivatives(x_mid, y_mid, theta_mid, k3_x, k3_y, k3_theta);
+
+  // k4: derivatives at end using k3.
+  double x_end = x_ + dt * k3_x;
+  double y_end = y_ + dt * k3_y;
+  double theta_end = theta_ + dt * k3_theta;
+  computeDerivatives(x_end, y_end, theta_end, k4_x, k4_y, k4_theta);
+
+  // Combine increments.
+  x_ += (dt / 6.0) * (k1_x + 2.0 * k2_x + 2.0 * k3_x + k4_x);
+  y_ += (dt / 6.0) * (k1_y + 2.0 * k2_y + 2.0 * k3_y + k4_y);
+  theta_ += (dt / 6.0) * (k1_theta + 2.0 * k2_theta + 2.0 * k3_theta + k4_theta);
+}
+
+void Unicycle::update(double dt) {
+  integrateRK4(dt);
+}

--- a/src/unicycle_robot_node.cpp
+++ b/src/unicycle_robot_node.cpp
@@ -1,0 +1,101 @@
+#include <chrono>
+#include <memory>
+#include "rclcpp/rclcpp.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
+#include "cddp_mpc/unicycle.hpp"
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+using namespace std::chrono_literals;
+
+class UnicycleRobotNode : public rclcpp::Node {
+public:
+  UnicycleRobotNode()
+  : Node("unicycle_robot_node")
+  {
+    // Declare and retrieve the robot_id parameter (default "robot_1")
+    this->declare_parameter<std::string>("robot_id", "robot_1");
+    robot_id_ = this->get_parameter("robot_id").as_string();
+
+    // Declare and retrieve initial pose parameters (default to 0.0)
+    this->declare_parameter<double>("init_x", 0.0);
+    this->declare_parameter<double>("init_y", 0.0);
+    this->declare_parameter<double>("init_yaw", 0.0);
+    double init_x = this->get_parameter("init_x").as_double();
+    double init_y = this->get_parameter("init_y").as_double();
+    double init_yaw = this->get_parameter("init_yaw").as_double();
+
+    // Create the unicycle instance with the initial pose.
+    unicycle_ = std::make_shared<Unicycle>(init_x, init_y, init_yaw);
+
+    // Construct topic names using robot_id.
+    std::string cmd_vel_topic = robot_id_ + "/cmd_vel";
+    std::string pose_topic = robot_id_ + "/pose";
+
+    // Subscribe to velocity commands on the constructed topic.
+    cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      cmd_vel_topic, 10,
+      std::bind(&UnicycleRobotNode::cmdVelCallback, this, std::placeholders::_1)
+    );
+    
+    // Publisher for robot state as PoseStamped on the constructed topic.
+    pose_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>(pose_topic, 10);
+
+    // Timer to update simulation at fixed intervals.
+    timer_ = this->create_wall_timer(50ms, std::bind(&UnicycleRobotNode::updateSimulation, this));
+    
+    last_time_ = this->now();
+  }
+
+private:
+  // Callback to update the unicycle commands from incoming Twist messages.
+  void cmdVelCallback(const geometry_msgs::msg::Twist::SharedPtr msg) {
+    unicycle_->setCommand(msg->linear.x, msg->angular.z);
+  }
+
+  // Update simulation state and publish the robot state as a PoseStamped message.
+  void updateSimulation() {
+    // Compute elapsed time.
+    auto current_time = this->now();
+    double dt = (current_time - last_time_).seconds();
+    last_time_ = current_time;
+
+    // Propagate the unicycle state.
+    unicycle_->update(dt);
+    auto state = unicycle_->getState(); // [x, y, theta]
+
+    // Prepare and publish the PoseStamped message.
+    auto pose_msg = geometry_msgs::msg::PoseStamped();
+    pose_msg.header.stamp = current_time;
+    // Using robot_id as the header frame_id for reference.
+    pose_msg.header.frame_id = "map";
+
+    pose_msg.pose.position.x = state[0];
+    pose_msg.pose.position.y = state[1];
+    pose_msg.pose.position.z = 0.0;
+
+    // Convert yaw (theta) to a quaternion.
+    tf2::Quaternion q;
+    q.setRPY(0.0, 0.0, state[2]);
+    pose_msg.pose.orientation = tf2::toMsg(q);
+
+    pose_pub_->publish(pose_msg);
+  }
+
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Time last_time_;
+
+  std::string robot_id_;
+  std::shared_ptr<Unicycle> unicycle_;
+};
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<UnicycleRobotNode>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
Restore the archived pre-PX4 ground-robot MPC demo assets while keeping the PX4 workflow as the default supported path.

## Changes
- restore the historical unicycle and car MPC sources, launch file, RViz config, and demo GIF from the merged #13 state
- gate the archived executables behind `BUILD_LEGACY_GROUND_DEMOS=ON`
- document the archived demo flow in `legacy/README.md` and surface the GIF in the top-level README

## Test Plan
- `git diff --check`
- `python3 -m py_compile launch/simple_robot_bringup.launch.py`
- Not run: `colcon build --packages-select cddp_mpc --cmake-args -DBUILD_LEGACY_GROUND_DEMOS=ON`

## Related Issues
- None

## How to Test
- build with `colcon build --packages-select cddp_mpc --cmake-args -DBUILD_LEGACY_GROUND_DEMOS=ON`
- source the workspace overlay
- launch `ros2 launch cddp_mpc simple_robot_bringup.launch.py`
- optionally run `ros2 run cddp_mpc legacy_teleop_keyboard_node --ros-args -p robot_id:=robot_1`

## Screenshots/Videos
- restores `video/cddp_mpc_demo.gif` and embeds it in the README

## Additional Notes
- `.codex` remains uncommitted
- the archived MPC nodes still expect `/robot_1/global_path`, so the restored launch is reference-grade rather than a fully maintained end-to-end flow
