### PR TITLE
Add gamepad teleop node for offboard control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,13 @@ ament_target_dependencies(px4_visualizer
   visualization_msgs
 )
 
+add_executable(gamepad_teleop_node src/teleop_keyboard.cpp)
+ament_target_dependencies(gamepad_teleop_node
+  geometry_msgs
+  rclcpp
+  sensor_msgs
+)
+
 if(BUILD_LEGACY_GROUND_DEMOS)
   find_package(tf2 REQUIRED)
   find_package(tf2_geometry_msgs REQUIRED)
@@ -144,13 +151,14 @@ if(BUILD_LEGACY_GROUND_DEMOS)
   add_executable(legacy_teleop_keyboard_node
     src/teleop_keyboard.cpp
   )
-  ament_target_dependencies(legacy_teleop_keyboard_node rclcpp geometry_msgs)
+  ament_target_dependencies(legacy_teleop_keyboard_node rclcpp geometry_msgs sensor_msgs)
 
   add_executable(legacy_hardcoded_map_node src/hardcoded_map_node.cpp)
   ament_target_dependencies(legacy_hardcoded_map_node rclcpp nav_msgs geometry_msgs)
 endif()
 
 install(TARGETS
+  gamepad_teleop_node
   px4_mpc_node
   px4_visualizer
   DESTINATION lib/${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ ament_target_dependencies(px4_visualizer
   visualization_msgs
 )
 
-add_executable(gamepad_teleop_node src/teleop_keyboard.cpp)
+add_executable(gamepad_teleop_node src/gamepad_teleop_node.cpp)
 ament_target_dependencies(gamepad_teleop_node
   geometry_msgs
   rclcpp
@@ -151,7 +151,7 @@ if(BUILD_LEGACY_GROUND_DEMOS)
   add_executable(legacy_teleop_keyboard_node
     src/teleop_keyboard.cpp
   )
-  ament_target_dependencies(legacy_teleop_keyboard_node rclcpp geometry_msgs sensor_msgs)
+  ament_target_dependencies(legacy_teleop_keyboard_node rclcpp geometry_msgs)
 
   add_executable(legacy_hardcoded_map_node src/hardcoded_map_node.cpp)
   ament_target_dependencies(legacy_hardcoded_map_node rclcpp nav_msgs geometry_msgs)

--- a/launch/mpc_offboard.launch.py
+++ b/launch/mpc_offboard.launch.py
@@ -75,6 +75,12 @@ def _prefix_parent(prefix: str, leaf: str) -> str:
     return "/"
 
 
+def _vehicle_topic(prefix: str, leaf: str) -> str:
+    if prefix == "/":
+        return f"/{leaf}"
+    return f"{prefix}/{leaf}"
+
+
 def _rewrite_rviz_config(source_path: str, controller_prefix: str, visualizer_prefix: str) -> str:
     text = Path(source_path).read_text()
     text = text.replace("/cddp_mpc", controller_prefix)
@@ -100,6 +106,8 @@ def _build_actions(context, *args, **kwargs):
         namespace, LaunchConfiguration("visualizer_prefix").perform(context), "px4_visualizer"
     )
     vehicle_prefix = _prefix_parent(controller_prefix, "cddp_mpc")
+    joy_topic = _vehicle_topic(vehicle_prefix, "joy")
+    teleop_topic = _vehicle_topic(vehicle_prefix, "teleop/cmd_vel")
     params_overlay = LaunchConfiguration("params_overlay").perform(context).strip()
     launch_visualizer = _as_bool(LaunchConfiguration("launch_visualizer").perform(context))
     launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
@@ -115,6 +123,8 @@ def _build_actions(context, *args, **kwargs):
             "fmu_prefix": fmu_prefix,
             "controller_prefix": controller_prefix,
             "goal_pose_topic": f"{controller_prefix}/goal_pose",
+            "joy_topic": joy_topic,
+            "teleop_topic": teleop_topic,
             "target_system": int(LaunchConfiguration("target_system").perform(context)),
             "target_component": int(LaunchConfiguration("target_component").perform(context)),
             "source_system": int(LaunchConfiguration("source_system").perform(context)),
@@ -143,12 +153,8 @@ def _build_actions(context, *args, **kwargs):
                 output="screen",
                 parameters=[
                     {
-                        "joy_topic": f"{vehicle_prefix}/joy"
-                        if vehicle_prefix != "/"
-                        else "/joy",
-                        "teleop_topic": f"{vehicle_prefix}/teleop/cmd_vel"
-                        if vehicle_prefix != "/"
-                        else "/teleop/cmd_vel",
+                        "joy_topic": joy_topic,
+                        "teleop_topic": teleop_topic,
                     }
                 ],
             )

--- a/launch/mpc_offboard.launch.py
+++ b/launch/mpc_offboard.launch.py
@@ -67,6 +67,14 @@ def _default_prefix(namespace: str, explicit_prefix: str, leaf: str) -> str:
     return f"/{leaf}"
 
 
+def _prefix_parent(prefix: str, leaf: str) -> str:
+    suffix = f"/{leaf}"
+    if prefix.endswith(suffix):
+        parent = prefix[: -len(suffix)]
+        return parent or "/"
+    return "/"
+
+
 def _rewrite_rviz_config(source_path: str, controller_prefix: str, visualizer_prefix: str) -> str:
     text = Path(source_path).read_text()
     text = text.replace("/cddp_mpc", controller_prefix)
@@ -91,9 +99,13 @@ def _build_actions(context, *args, **kwargs):
     visualizer_prefix = _default_prefix(
         namespace, LaunchConfiguration("visualizer_prefix").perform(context), "px4_visualizer"
     )
+    vehicle_prefix = _prefix_parent(controller_prefix, "cddp_mpc")
     params_overlay = LaunchConfiguration("params_overlay").perform(context).strip()
     launch_visualizer = _as_bool(LaunchConfiguration("launch_visualizer").perform(context))
     launch_rviz = _as_bool(LaunchConfiguration("launch_rviz").perform(context))
+    launch_gamepad_teleop = _as_bool(
+        LaunchConfiguration("launch_gamepad_teleop").perform(context)
+    )
 
     controller_parameters = [LaunchConfiguration("params_file")]
     if params_overlay:
@@ -120,6 +132,27 @@ def _build_actions(context, *args, **kwargs):
             parameters=controller_parameters,
         )
     ]
+
+    if launch_gamepad_teleop:
+        actions.append(
+            Node(
+                package=package_name,
+                executable="gamepad_teleop_node",
+                namespace=namespace,
+                name="gamepad_teleop",
+                output="screen",
+                parameters=[
+                    {
+                        "joy_topic": f"{vehicle_prefix}/joy"
+                        if vehicle_prefix != "/"
+                        else "/joy",
+                        "teleop_topic": f"{vehicle_prefix}/teleop/cmd_vel"
+                        if vehicle_prefix != "/"
+                        else "/teleop/cmd_vel",
+                    }
+                ],
+            )
+        )
 
     if launch_visualizer or launch_rviz:
         actions.append(
@@ -203,6 +236,11 @@ def generate_launch_description():
             DeclareLaunchArgument("target_component", default_value="1"),
             DeclareLaunchArgument("source_system", default_value="1"),
             DeclareLaunchArgument("source_component", default_value="1"),
+            DeclareLaunchArgument(
+                "launch_gamepad_teleop",
+                default_value="false",
+                description="Launch the Joy-to-TwistStamped gamepad teleop helper node.",
+            ),
             DeclareLaunchArgument(
                 "launch_visualizer",
                 default_value="false",

--- a/src/gamepad_teleop_node.cpp
+++ b/src/gamepad_teleop_node.cpp
@@ -1,0 +1,178 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <string>
+
+#include "geometry_msgs/msg/twist_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/joy.hpp"
+
+class GamepadTeleop : public rclcpp::Node {
+public:
+  GamepadTeleop() : Node("gamepad_teleop") {
+    loadParameters();
+
+    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(
+        joy_topic_, rclcpp::QoS(10),
+        std::bind(&GamepadTeleop::joyCallback, this, std::placeholders::_1));
+    teleop_pub_ =
+        create_publisher<geometry_msgs::msg::TwistStamped>(teleop_topic_, rclcpp::QoS(10));
+
+    const auto period = std::chrono::duration<double>(1.0 / std::max(publish_rate_hz_, 1.0));
+    timer_ = create_wall_timer(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+        std::bind(&GamepadTeleop::publishCommand, this));
+
+    RCLCPP_INFO(
+        get_logger(),
+        "Gamepad teleop ready: joy_topic=%s teleop_topic=%s publish_rate_hz=%.1f",
+        joy_topic_.c_str(), teleop_topic_.c_str(), publish_rate_hz_);
+  }
+
+private:
+  template <typename T> T declareOrGet(const std::string &name, const T &default_value) {
+    if (!has_parameter(name)) {
+      declare_parameter<T>(name, default_value);
+    }
+    return get_parameter(name).template get_value<T>();
+  }
+
+  void loadParameters() {
+    joy_topic_ = declareOrGet("joy_topic", std::string("/joy"));
+    teleop_topic_ = declareOrGet("teleop_topic", std::string("/teleop/cmd_vel"));
+    frame_id_ = declareOrGet("frame_id", std::string("base_link"));
+    publish_rate_hz_ = declareOrGet("publish_rate_hz", 30.0);
+    command_timeout_s_ = declareOrGet("command_timeout_s", 0.25);
+    deadzone_ = declareOrGet("deadzone", 0.10);
+
+    axis_forward_ = declareOrGet("axis_forward", 1);
+    axis_lateral_ = declareOrGet("axis_lateral", 0);
+    axis_yaw_ = declareOrGet("axis_yaw", 3);
+    axis_descend_ = declareOrGet("axis_descend", 2);
+    axis_ascend_ = declareOrGet("axis_ascend", 5);
+
+    scale_forward_ = declareOrGet("scale_forward", 1.0);
+    scale_lateral_ = declareOrGet("scale_lateral", 1.0);
+    scale_yaw_ = declareOrGet("scale_yaw", 1.0);
+    scale_vertical_ = declareOrGet("scale_vertical", 1.0);
+
+    trigger_released_value_ = declareOrGet("trigger_released_value", 1.0);
+    trigger_pressed_value_ = declareOrGet("trigger_pressed_value", -1.0);
+
+    max_forward_mps_ = declareOrGet("max_forward_mps", 1.0);
+    max_lateral_mps_ = declareOrGet("max_lateral_mps", 1.0);
+    max_vertical_mps_ = declareOrGet("max_vertical_mps", 0.6);
+    max_yaw_rate_rad_s_ = declareOrGet("max_yaw_rate_rad_s", 0.8);
+  }
+
+  static double clampUnit(double value) { return std::clamp(value, -1.0, 1.0); }
+
+  double axisValue(const sensor_msgs::msg::Joy &msg, int index, double scale) const {
+    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
+      return 0.0;
+    }
+
+    double value = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]) * scale;
+    if (std::abs(value) < deadzone_) {
+      return 0.0;
+    }
+
+    const double sign = value >= 0.0 ? 1.0 : -1.0;
+    const double magnitude = (std::abs(value) - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
+    return sign * clampUnit(magnitude);
+  }
+
+  double triggerValue(const sensor_msgs::msg::Joy &msg, int index) const {
+    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
+      return 0.0;
+    }
+
+    const double raw = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]);
+    const double denominator = trigger_released_value_ - trigger_pressed_value_;
+    if (std::abs(denominator) < 1e-6) {
+      return 0.0;
+    }
+
+    const double pressed = (trigger_released_value_ - raw) / denominator;
+    const double clamped = std::clamp(pressed, 0.0, 1.0);
+    if (clamped < deadzone_) {
+      return 0.0;
+    }
+    return (clamped - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
+  }
+
+  void joyCallback(const sensor_msgs::msg::Joy::SharedPtr msg) {
+    latest_joy_ = msg;
+    last_joy_time_ = now();
+  }
+
+  void publishCommand() {
+    geometry_msgs::msg::TwistStamped command;
+    command.header.stamp = now();
+    command.header.frame_id = frame_id_;
+
+    if (latest_joy_) {
+      const double age_s = (now() - last_joy_time_).seconds();
+      if (std::isfinite(age_s) && age_s <= command_timeout_s_) {
+        const double forward = axisValue(*latest_joy_, axis_forward_, scale_forward_);
+        const double lateral = axisValue(*latest_joy_, axis_lateral_, scale_lateral_);
+        const double yaw = axisValue(*latest_joy_, axis_yaw_, scale_yaw_);
+        const double ascend = triggerValue(*latest_joy_, axis_ascend_);
+        const double descend = triggerValue(*latest_joy_, axis_descend_);
+        const double vertical = clampUnit((ascend - descend) * scale_vertical_);
+
+        command.twist.linear.x = forward * max_forward_mps_;
+        command.twist.linear.y = lateral * max_lateral_mps_;
+        command.twist.linear.z = vertical * max_vertical_mps_;
+        command.twist.angular.z = yaw * max_yaw_rate_rad_s_;
+      }
+    }
+
+    teleop_pub_->publish(command);
+  }
+
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr teleop_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  sensor_msgs::msg::Joy::SharedPtr latest_joy_;
+  rclcpp::Time last_joy_time_{0, 0, RCL_ROS_TIME};
+
+  std::string joy_topic_;
+  std::string teleop_topic_;
+  std::string frame_id_;
+
+  double publish_rate_hz_{30.0};
+  double command_timeout_s_{0.25};
+  double deadzone_{0.10};
+
+  int axis_forward_{1};
+  int axis_lateral_{0};
+  int axis_yaw_{3};
+  int axis_descend_{2};
+  int axis_ascend_{5};
+
+  double scale_forward_{1.0};
+  double scale_lateral_{1.0};
+  double scale_yaw_{1.0};
+  double scale_vertical_{1.0};
+
+  double trigger_released_value_{1.0};
+  double trigger_pressed_value_{-1.0};
+
+  double max_forward_mps_{1.0};
+  double max_lateral_mps_{1.0};
+  double max_vertical_mps_{0.6};
+  double max_yaw_rate_rad_s_{0.8};
+};
+
+int main(int argc, char *argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<GamepadTeleop>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/teleop_keyboard.cpp
+++ b/src/teleop_keyboard.cpp
@@ -1,112 +1,177 @@
+#include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <string>
-#include <thread>
-#include <iostream>
-#include <termios.h>
-#include <unistd.h>
 
+#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "geometry_msgs/msg/twist.hpp"
+#include "sensor_msgs/msg/joy.hpp"
 
-using namespace std::chrono_literals;
-
-class TeleopKeyboard : public rclcpp::Node {
+class GamepadTeleop : public rclcpp::Node {
 public:
-  TeleopKeyboard()
-  : Node("teleop_keyboard")
-  {
-    // Declare and retrieve the robot_id parameter (default "robot_1")
-    this->declare_parameter<std::string>("robot_id", "robot_1");
-    robot_id_ = this->get_parameter("robot_id").as_string();
+  GamepadTeleop() : Node("gamepad_teleop") {
+    loadParameters();
 
-    // Construct the cmd_vel topic based on robot_id.
-    std::string cmd_vel_topic = robot_id_ + "/cmd_vel";
-    publisher_ = this->create_publisher<geometry_msgs::msg::Twist>(cmd_vel_topic, 10);
+    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(
+        joy_topic_, rclcpp::QoS(10),
+        std::bind(&GamepadTeleop::joyCallback, this, std::placeholders::_1));
+    teleop_pub_ =
+        create_publisher<geometry_msgs::msg::TwistStamped>(teleop_topic_, rclcpp::QoS(10));
 
-    // Start the keyboard reading thread.
-    keyboard_thread_ = std::thread(std::bind(&TeleopKeyboard::keyboardLoop, this));
+    const auto period = std::chrono::duration<double>(1.0 / std::max(publish_rate_hz_, 1.0));
+    timer_ = create_wall_timer(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
+        std::bind(&GamepadTeleop::publishCommand, this));
+
+    RCLCPP_INFO(
+        get_logger(),
+        "Gamepad teleop ready: joy_topic=%s teleop_topic=%s publish_rate_hz=%.1f",
+        joy_topic_.c_str(), teleop_topic_.c_str(), publish_rate_hz_);
   }
-  
-  ~TeleopKeyboard() {
-    exit_requested_ = true;
-    if (keyboard_thread_.joinable()) {
-      keyboard_thread_.join();
-    }
-  }
-  
+
 private:
-  void keyboardLoop() {
-    char c;
-    double linear_vel = 0.0;
-    double angular_vel = 0.0;
-    const double linear_step = 0.1;
-    const double angular_step = 0.1;
-    
-    // Set terminal to raw mode for immediate key press reading.
-    struct termios oldt, newt;
-    tcgetattr(STDIN_FILENO, &oldt);
-    newt = oldt;
-    newt.c_lflag &= ~(ICANON | ECHO);
-    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-    
-    std::cout << "\nTeleop Keyboard Control for robot: " << robot_id_ << "\n";
-    std::cout << "-----------------------------------------\n";
-    std::cout << "w: increase forward speed\n";
-    std::cout << "s: decrease forward speed (or move backwards)\n";
-    std::cout << "a: turn left\n";
-    std::cout << "d: turn right\n";
-    std::cout << "x: stop\n";
-    std::cout << "q: quit\n";
-    
-    while (rclcpp::ok() && !exit_requested_) {
-      if (read(STDIN_FILENO, &c, 1) > 0) {
-        geometry_msgs::msg::Twist twist_msg;
-        switch (c) {
-          case 'w':
-            linear_vel += linear_step;
-            break;
-          case 's':
-            linear_vel -= linear_step;
-            break;
-          case 'a':
-            angular_vel += angular_step;
-            break;
-          case 'd':
-            angular_vel -= angular_step;
-            break;
-          case 'x':
-            linear_vel = 0.0;
-            angular_vel = 0.0;
-            break;
-          case 'q':
-            exit_requested_ = true;
-            break;
-          default:
-            break;
-        }
-        twist_msg.linear.x = linear_vel;
-        twist_msg.angular.z = angular_vel;
-        publisher_->publish(twist_msg);
-        std::cout << "Published to " << robot_id_ << "/cmd_vel: linear = " 
-                  << twist_msg.linear.x << ", angular = " << twist_msg.angular.z << "\n";
+  template <typename T> T declareOrGet(const std::string &name, const T &default_value) {
+    if (!has_parameter(name)) {
+      declare_parameter<T>(name, default_value);
+    }
+    return get_parameter(name).template get_value<T>();
+  }
+
+  void loadParameters() {
+    joy_topic_ = declareOrGet("joy_topic", std::string("/joy"));
+    teleop_topic_ = declareOrGet("teleop_topic", std::string("/teleop/cmd_vel"));
+    frame_id_ = declareOrGet("frame_id", std::string("base_link"));
+    publish_rate_hz_ = declareOrGet("publish_rate_hz", 30.0);
+    command_timeout_s_ = declareOrGet("command_timeout_s", 0.25);
+    deadzone_ = declareOrGet("deadzone", 0.10);
+
+    axis_forward_ = declareOrGet("axis_forward", 1);
+    axis_lateral_ = declareOrGet("axis_lateral", 0);
+    axis_yaw_ = declareOrGet("axis_yaw", 3);
+    axis_descend_ = declareOrGet("axis_descend", 2);
+    axis_ascend_ = declareOrGet("axis_ascend", 5);
+
+    scale_forward_ = declareOrGet("scale_forward", 1.0);
+    scale_lateral_ = declareOrGet("scale_lateral", 1.0);
+    scale_yaw_ = declareOrGet("scale_yaw", 1.0);
+    scale_vertical_ = declareOrGet("scale_vertical", 1.0);
+
+    trigger_released_value_ = declareOrGet("trigger_released_value", 1.0);
+    trigger_pressed_value_ = declareOrGet("trigger_pressed_value", -1.0);
+
+    max_forward_mps_ = declareOrGet("max_forward_mps", 1.0);
+    max_lateral_mps_ = declareOrGet("max_lateral_mps", 1.0);
+    max_vertical_mps_ = declareOrGet("max_vertical_mps", 0.6);
+    max_yaw_rate_rad_s_ = declareOrGet("max_yaw_rate_rad_s", 0.8);
+  }
+
+  static double clampUnit(double value) { return std::clamp(value, -1.0, 1.0); }
+
+  double axisValue(const sensor_msgs::msg::Joy &msg, int index, double scale) const {
+    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
+      return 0.0;
+    }
+
+    double value = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]) * scale;
+    if (std::abs(value) < deadzone_) {
+      return 0.0;
+    }
+
+    const double sign = value >= 0.0 ? 1.0 : -1.0;
+    const double magnitude = (std::abs(value) - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
+    return sign * clampUnit(magnitude);
+  }
+
+  double triggerValue(const sensor_msgs::msg::Joy &msg, int index) const {
+    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
+      return 0.0;
+    }
+
+    const double raw = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]);
+    const double denominator = trigger_released_value_ - trigger_pressed_value_;
+    if (std::abs(denominator) < 1e-6) {
+      return 0.0;
+    }
+
+    const double pressed = (trigger_released_value_ - raw) / denominator;
+    const double clamped = std::clamp(pressed, 0.0, 1.0);
+    if (clamped < deadzone_) {
+      return 0.0;
+    }
+    return (clamped - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
+  }
+
+  void joyCallback(const sensor_msgs::msg::Joy::SharedPtr msg) {
+    latest_joy_ = msg;
+    last_joy_time_ = now();
+  }
+
+  void publishCommand() {
+    geometry_msgs::msg::TwistStamped command;
+    command.header.stamp = now();
+    command.header.frame_id = frame_id_;
+
+    if (latest_joy_) {
+      const double age_s = (now() - last_joy_time_).seconds();
+      if (std::isfinite(age_s) && age_s <= command_timeout_s_) {
+        const double forward = axisValue(*latest_joy_, axis_forward_, scale_forward_);
+        const double lateral = axisValue(*latest_joy_, axis_lateral_, scale_lateral_);
+        const double yaw = axisValue(*latest_joy_, axis_yaw_, scale_yaw_);
+        const double ascend = triggerValue(*latest_joy_, axis_ascend_);
+        const double descend = triggerValue(*latest_joy_, axis_descend_);
+        const double vertical = clampUnit((ascend - descend) * scale_vertical_);
+
+        command.twist.linear.x = forward * max_forward_mps_;
+        command.twist.linear.y = lateral * max_lateral_mps_;
+        command.twist.linear.z = vertical * max_vertical_mps_;
+        command.twist.angular.z = yaw * max_yaw_rate_rad_s_;
       }
     }
-    // Restore terminal settings before exit.
-    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+
+    teleop_pub_->publish(command);
   }
-  
-  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
-  std::thread keyboard_thread_;
-  bool exit_requested_{false};
-  std::string robot_id_;
+
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
+  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr teleop_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  sensor_msgs::msg::Joy::SharedPtr latest_joy_;
+  rclcpp::Time last_joy_time_{0, 0, RCL_ROS_TIME};
+
+  std::string joy_topic_;
+  std::string teleop_topic_;
+  std::string frame_id_;
+
+  double publish_rate_hz_{30.0};
+  double command_timeout_s_{0.25};
+  double deadzone_{0.10};
+
+  int axis_forward_{1};
+  int axis_lateral_{0};
+  int axis_yaw_{3};
+  int axis_descend_{2};
+  int axis_ascend_{5};
+
+  double scale_forward_{1.0};
+  double scale_lateral_{1.0};
+  double scale_yaw_{1.0};
+  double scale_vertical_{1.0};
+
+  double trigger_released_value_{1.0};
+  double trigger_pressed_value_{-1.0};
+
+  double max_forward_mps_{1.0};
+  double max_lateral_mps_{1.0};
+  double max_vertical_mps_{0.6};
+  double max_yaw_rate_rad_s_{0.8};
 };
 
-int main(int argc, char * argv[])
-{
+int main(int argc, char *argv[]) {
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<TeleopKeyboard>();
+  auto node = std::make_shared<GamepadTeleop>();
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;

--- a/src/teleop_keyboard.cpp
+++ b/src/teleop_keyboard.cpp
@@ -1,177 +1,112 @@
-#include <algorithm>
 #include <chrono>
-#include <cmath>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <string>
+#include <thread>
+#include <iostream>
+#include <termios.h>
+#include <unistd.h>
 
-#include "geometry_msgs/msg/twist_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/joy.hpp"
+#include "geometry_msgs/msg/twist.hpp"
 
-class GamepadTeleop : public rclcpp::Node {
+using namespace std::chrono_literals;
+
+class TeleopKeyboard : public rclcpp::Node {
 public:
-  GamepadTeleop() : Node("gamepad_teleop") {
-    loadParameters();
+  TeleopKeyboard()
+  : Node("teleop_keyboard")
+  {
+    // Declare and retrieve the robot_id parameter (default "robot_1")
+    this->declare_parameter<std::string>("robot_id", "robot_1");
+    robot_id_ = this->get_parameter("robot_id").as_string();
 
-    joy_sub_ = create_subscription<sensor_msgs::msg::Joy>(
-        joy_topic_, rclcpp::QoS(10),
-        std::bind(&GamepadTeleop::joyCallback, this, std::placeholders::_1));
-    teleop_pub_ =
-        create_publisher<geometry_msgs::msg::TwistStamped>(teleop_topic_, rclcpp::QoS(10));
+    // Construct the cmd_vel topic based on robot_id.
+    std::string cmd_vel_topic = robot_id_ + "/cmd_vel";
+    publisher_ = this->create_publisher<geometry_msgs::msg::Twist>(cmd_vel_topic, 10);
 
-    const auto period = std::chrono::duration<double>(1.0 / std::max(publish_rate_hz_, 1.0));
-    timer_ = create_wall_timer(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(period),
-        std::bind(&GamepadTeleop::publishCommand, this));
+    // Start the keyboard reading thread.
+    keyboard_thread_ = std::thread(std::bind(&TeleopKeyboard::keyboardLoop, this));
+  }
 
-    RCLCPP_INFO(
-        get_logger(),
-        "Gamepad teleop ready: joy_topic=%s teleop_topic=%s publish_rate_hz=%.1f",
-        joy_topic_.c_str(), teleop_topic_.c_str(), publish_rate_hz_);
+  ~TeleopKeyboard() {
+    exit_requested_ = true;
+    if (keyboard_thread_.joinable()) {
+      keyboard_thread_.join();
+    }
   }
 
 private:
-  template <typename T> T declareOrGet(const std::string &name, const T &default_value) {
-    if (!has_parameter(name)) {
-      declare_parameter<T>(name, default_value);
-    }
-    return get_parameter(name).template get_value<T>();
-  }
+  void keyboardLoop() {
+    char c;
+    double linear_vel = 0.0;
+    double angular_vel = 0.0;
+    const double linear_step = 0.1;
+    const double angular_step = 0.1;
 
-  void loadParameters() {
-    joy_topic_ = declareOrGet("joy_topic", std::string("/joy"));
-    teleop_topic_ = declareOrGet("teleop_topic", std::string("/teleop/cmd_vel"));
-    frame_id_ = declareOrGet("frame_id", std::string("base_link"));
-    publish_rate_hz_ = declareOrGet("publish_rate_hz", 30.0);
-    command_timeout_s_ = declareOrGet("command_timeout_s", 0.25);
-    deadzone_ = declareOrGet("deadzone", 0.10);
+    // Set terminal to raw mode for immediate key press reading.
+    struct termios oldt, newt;
+    tcgetattr(STDIN_FILENO, &oldt);
+    newt = oldt;
+    newt.c_lflag &= ~(ICANON | ECHO);
+    tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 
-    axis_forward_ = declareOrGet("axis_forward", 1);
-    axis_lateral_ = declareOrGet("axis_lateral", 0);
-    axis_yaw_ = declareOrGet("axis_yaw", 3);
-    axis_descend_ = declareOrGet("axis_descend", 2);
-    axis_ascend_ = declareOrGet("axis_ascend", 5);
+    std::cout << "\nTeleop Keyboard Control for robot: " << robot_id_ << "\n";
+    std::cout << "-----------------------------------------\n";
+    std::cout << "w: increase forward speed\n";
+    std::cout << "s: decrease forward speed (or move backwards)\n";
+    std::cout << "a: turn left\n";
+    std::cout << "d: turn right\n";
+    std::cout << "x: stop\n";
+    std::cout << "q: quit\n";
 
-    scale_forward_ = declareOrGet("scale_forward", 1.0);
-    scale_lateral_ = declareOrGet("scale_lateral", 1.0);
-    scale_yaw_ = declareOrGet("scale_yaw", 1.0);
-    scale_vertical_ = declareOrGet("scale_vertical", 1.0);
-
-    trigger_released_value_ = declareOrGet("trigger_released_value", 1.0);
-    trigger_pressed_value_ = declareOrGet("trigger_pressed_value", -1.0);
-
-    max_forward_mps_ = declareOrGet("max_forward_mps", 1.0);
-    max_lateral_mps_ = declareOrGet("max_lateral_mps", 1.0);
-    max_vertical_mps_ = declareOrGet("max_vertical_mps", 0.6);
-    max_yaw_rate_rad_s_ = declareOrGet("max_yaw_rate_rad_s", 0.8);
-  }
-
-  static double clampUnit(double value) { return std::clamp(value, -1.0, 1.0); }
-
-  double axisValue(const sensor_msgs::msg::Joy &msg, int index, double scale) const {
-    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
-      return 0.0;
-    }
-
-    double value = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]) * scale;
-    if (std::abs(value) < deadzone_) {
-      return 0.0;
-    }
-
-    const double sign = value >= 0.0 ? 1.0 : -1.0;
-    const double magnitude = (std::abs(value) - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
-    return sign * clampUnit(magnitude);
-  }
-
-  double triggerValue(const sensor_msgs::msg::Joy &msg, int index) const {
-    if (index < 0 || index >= static_cast<int>(msg.axes.size())) {
-      return 0.0;
-    }
-
-    const double raw = static_cast<double>(msg.axes[static_cast<std::size_t>(index)]);
-    const double denominator = trigger_released_value_ - trigger_pressed_value_;
-    if (std::abs(denominator) < 1e-6) {
-      return 0.0;
-    }
-
-    const double pressed = (trigger_released_value_ - raw) / denominator;
-    const double clamped = std::clamp(pressed, 0.0, 1.0);
-    if (clamped < deadzone_) {
-      return 0.0;
-    }
-    return (clamped - deadzone_) / std::max(1.0 - deadzone_, 1e-6);
-  }
-
-  void joyCallback(const sensor_msgs::msg::Joy::SharedPtr msg) {
-    latest_joy_ = msg;
-    last_joy_time_ = now();
-  }
-
-  void publishCommand() {
-    geometry_msgs::msg::TwistStamped command;
-    command.header.stamp = now();
-    command.header.frame_id = frame_id_;
-
-    if (latest_joy_) {
-      const double age_s = (now() - last_joy_time_).seconds();
-      if (std::isfinite(age_s) && age_s <= command_timeout_s_) {
-        const double forward = axisValue(*latest_joy_, axis_forward_, scale_forward_);
-        const double lateral = axisValue(*latest_joy_, axis_lateral_, scale_lateral_);
-        const double yaw = axisValue(*latest_joy_, axis_yaw_, scale_yaw_);
-        const double ascend = triggerValue(*latest_joy_, axis_ascend_);
-        const double descend = triggerValue(*latest_joy_, axis_descend_);
-        const double vertical = clampUnit((ascend - descend) * scale_vertical_);
-
-        command.twist.linear.x = forward * max_forward_mps_;
-        command.twist.linear.y = lateral * max_lateral_mps_;
-        command.twist.linear.z = vertical * max_vertical_mps_;
-        command.twist.angular.z = yaw * max_yaw_rate_rad_s_;
+    while (rclcpp::ok() && !exit_requested_) {
+      if (read(STDIN_FILENO, &c, 1) > 0) {
+        geometry_msgs::msg::Twist twist_msg;
+        switch (c) {
+          case 'w':
+            linear_vel += linear_step;
+            break;
+          case 's':
+            linear_vel -= linear_step;
+            break;
+          case 'a':
+            angular_vel += angular_step;
+            break;
+          case 'd':
+            angular_vel -= angular_step;
+            break;
+          case 'x':
+            linear_vel = 0.0;
+            angular_vel = 0.0;
+            break;
+          case 'q':
+            exit_requested_ = true;
+            break;
+          default:
+            break;
+        }
+        twist_msg.linear.x = linear_vel;
+        twist_msg.angular.z = angular_vel;
+        publisher_->publish(twist_msg);
+        std::cout << "Published to " << robot_id_ << "/cmd_vel: linear = "
+                  << twist_msg.linear.x << ", angular = " << twist_msg.angular.z << "\n";
       }
     }
-
-    teleop_pub_->publish(command);
+    // Restore terminal settings before exit.
+    tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
   }
 
-  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_sub_;
-  rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr teleop_pub_;
-  rclcpp::TimerBase::SharedPtr timer_;
-
-  sensor_msgs::msg::Joy::SharedPtr latest_joy_;
-  rclcpp::Time last_joy_time_{0, 0, RCL_ROS_TIME};
-
-  std::string joy_topic_;
-  std::string teleop_topic_;
-  std::string frame_id_;
-
-  double publish_rate_hz_{30.0};
-  double command_timeout_s_{0.25};
-  double deadzone_{0.10};
-
-  int axis_forward_{1};
-  int axis_lateral_{0};
-  int axis_yaw_{3};
-  int axis_descend_{2};
-  int axis_ascend_{5};
-
-  double scale_forward_{1.0};
-  double scale_lateral_{1.0};
-  double scale_yaw_{1.0};
-  double scale_vertical_{1.0};
-
-  double trigger_released_value_{1.0};
-  double trigger_pressed_value_{-1.0};
-
-  double max_forward_mps_{1.0};
-  double max_lateral_mps_{1.0};
-  double max_vertical_mps_{0.6};
-  double max_yaw_rate_rad_s_{0.8};
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr publisher_;
+  std::thread keyboard_thread_;
+  bool exit_requested_{false};
+  std::string robot_id_;
 };
 
-int main(int argc, char *argv[]) {
+int main(int argc, char * argv[])
+{
   rclcpp::init(argc, argv);
-  auto node = std::make_shared<GamepadTeleop>();
+  auto node = std::make_shared<TeleopKeyboard>();
   rclcpp::spin(node);
   rclcpp::shutdown();
   return 0;


### PR DESCRIPTION
## Summary
- replace the legacy keyboard teleop implementation with a ROS-native gamepad teleop node that converts `sensor_msgs/msg/Joy` into `geometry_msgs/msg/TwistStamped`
- build and install the new `gamepad_teleop_node` target while keeping the existing RViz interactive goal marker path unchanged
- add an optional `launch_gamepad_teleop` flag to `mpc_offboard.launch.py` and wire the node to the same namespaced `joy` and `teleop/cmd_vel` topics used by `px4_mpc_node`

## Testing
- `python3 -m py_compile launch/mpc_offboard.launch.py`
- Not run: C++/ROS build in this environment. A fresh configure failed because `ament_cmake` is not available on the current `CMAKE_PREFIX_PATH`, and the checked-in `build/` directory contains a stale CMake cache from another checkout.
